### PR TITLE
feat: list account assets

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -15,6 +15,10 @@ on:
         required: true
       PRICE_API_BASE_URL_LOCAL:
         required: true
+      TOKEN_API_BASE_URL:
+        required: true
+      TOKEN_API_KEY:
+        required: true
 
 jobs:
   prepare:
@@ -42,6 +46,8 @@ jobs:
       RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
       PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
       PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+      TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+      TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -107,6 +113,8 @@ jobs:
       RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
       PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
       PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+      TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+      TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}
       LOCAL: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -64,3 +64,5 @@ jobs:
           RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
           PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
           PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+          TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+          TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
       PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
       PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+      TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+      TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}
 
   sonarcloud:
     permissions:
@@ -109,3 +111,5 @@ jobs:
       RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
       PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
       PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+      TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+      TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,8 @@ jobs:
       RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
       PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
       PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+      TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+      TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}
 
   sonarcloud:
     permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,10 @@ on:
         required: true
       PRICE_API_BASE_URL_LOCAL:
         required: true
+      TOKEN_API_BASE_URL:
+        required: true
+      TOKEN_API_KEY:
+        required: true
 
 jobs:
   publish-release:
@@ -47,6 +51,8 @@ jobs:
           RPC_URL_LOCALNET_LIST: ${{ secrets.RPC_URL_LOCALNET_LIST }}
           PRICE_API_BASE_URL: ${{ secrets.PRICE_API_BASE_URL }}
           PRICE_API_BASE_URL_LOCAL: ${{ secrets.PRICE_API_BASE_URL_LOCAL }}
+          TOKEN_API_BASE_URL: ${{ secrets.TOKEN_API_BASE_URL }}
+          TOKEN_API_KEY: ${{ secrets.TOKEN_API_KEY }}
       - uses: actions/cache@v4
         id: restore-build
         with:

--- a/packages/site/src/context/network.tsx
+++ b/packages/site/src/context/network.tsx
@@ -29,7 +29,7 @@ export const NetworkProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [network, setNetwork] = useState<Network>(SolanaCaip2Networks.Devnet);
+  const [network, setNetwork] = useState<Network>(SolanaCaip2Networks.Mainnet);
 
   return (
     <NetworkContext.Provider value={{ network, setNetwork }}>

--- a/packages/snap/snap.config.ts
+++ b/packages/snap/snap.config.ts
@@ -12,6 +12,8 @@ const environment = {
   RPC_URL_LOCALNET_LIST: process.env.RPC_URL_LOCALNET_LIST ?? '',
   PRICE_API_BASE_URL: process.env.PRICE_API_BASE_URL ?? '',
   PRICE_API_BASE_URL_LOCAL: process.env.PRICE_API_BASE_URL_LOCAL ?? '',
+  TOKEN_API_BASE_URL: process.env.TOKEN_API_BASE_URL ?? '',
+  TOKEN_API_KEY: process.env.TOKEN_API_KEY ?? '',
   LOCAL: process.env.LOCAL,
 };
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "PVMsjhxdZwSLN5YI/AnrVxI56diLxXNQZzk5Z6wM8y4=",
+    "shasum": "52J7tjLeWnh/x+4tVJspLkSvfGVqITim45nAh0DbdtA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/clients/token-metadata-client/token-metadata-client.test.ts
+++ b/packages/snap/src/core/clients/token-metadata-client/token-metadata-client.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { SolanaCaip2Networks } from '../../constants/solana';
+import type { ConfigProvider } from '../../services/config';
+import type { ILogger } from '../../utils/logger';
+import { TokenMetadataClient } from './token-metadata-client';
+import type { TokenMetadata, TokenMetadataResponse } from './types';
+
+describe('TokenMetadataClient', () => {
+  const mockFetch = jest.fn();
+  const mockLogger = {
+    error: jest.fn(),
+  } as unknown as ILogger;
+
+  let client: TokenMetadataClient;
+  let mockConfigProvider: ConfigProvider;
+
+  beforeEach(() => {
+    mockConfigProvider = {
+      get: jest.fn().mockReturnValue({
+        tokenApi: {
+          baseUrl: 'https://some-mock-url.com',
+          apiKey: 'some-api-key',
+        },
+      }),
+    } as unknown as ConfigProvider;
+
+    client = new TokenMetadataClient(mockConfigProvider, mockFetch, mockLogger);
+  });
+
+  it('fetches and parses token metadata when one is returned', async () => {
+    const tokenAddresses = ['address1', 'address2'];
+    const mockFetchResponse: Partial<TokenMetadata> = {
+      fungible_id: 'solana.address1',
+      symbol: 'MOCK',
+      name: 'Mock Token',
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockFetchResponse),
+    });
+    const scope = SolanaCaip2Networks.Localnet;
+    const metadata = await client.getTokenMetadataFromAddresses(
+      tokenAddresses,
+      scope,
+    );
+
+    expect(metadata).toStrictEqual({
+      'solana:123456789abcdef/token:address1': {
+        iconUrl:
+          'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address1/logo.png',
+        name: 'Mock Token',
+        symbol: 'MOCK',
+      },
+    });
+  });
+
+  it('fetches and parses token metadata when multiple are returned', async () => {
+    const tokenAddresses = ['address1', 'address2'];
+    const mockFetchResponse = {
+      fungibles: [
+        {
+          fungible_id: 'solana.address1',
+          symbol: 'MOCK',
+          name: 'Mock Token',
+        },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockFetchResponse),
+    });
+    const scope = SolanaCaip2Networks.Localnet;
+    const metadata = await client.getTokenMetadataFromAddresses(
+      tokenAddresses,
+      scope,
+    );
+
+    expect(metadata).toStrictEqual({
+      'solana:123456789abcdef/token:address1': {
+        iconUrl:
+          'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address1/logo.png',
+        name: 'Mock Token',
+        symbol: 'MOCK',
+      },
+    });
+  });
+
+  it('throws an error if fetch fails', async () => {
+    const tokenAddresses = ['address1', 'address2'];
+    const errorMessage = 'Error fetching token metadata';
+    mockFetch.mockRejectedValueOnce(new Error(errorMessage));
+    const scope = SolanaCaip2Networks.Localnet;
+
+    await expect(
+      client.getTokenMetadataFromAddresses(tokenAddresses, scope),
+    ).rejects.toThrow(errorMessage);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      new Error(errorMessage),
+      errorMessage,
+    );
+  });
+});

--- a/packages/snap/src/core/clients/token-metadata-client/token-metadata-client.ts
+++ b/packages/snap/src/core/clients/token-metadata-client/token-metadata-client.ts
@@ -1,0 +1,89 @@
+import { SolanaCaip2Networks } from '../../constants/solana';
+import type { ConfigProvider } from '../../services/config';
+import type { ILogger } from '../../utils/logger';
+import logger from '../../utils/logger';
+import { tokenAddressToCaip19 } from '../../utils/token-address-to-caip19';
+import type {
+  SolanaTokenMetadata,
+  TokenMetadata,
+  TokenMetadataResponse,
+} from './types';
+
+const SCOPE_TO_NETWORK: Record<SolanaCaip2Networks, string> = {
+  [SolanaCaip2Networks.Mainnet]: 'solana',
+  [SolanaCaip2Networks.Devnet]: 'solana-devnet',
+  [SolanaCaip2Networks.Testnet]: 'solana-testnet',
+  [SolanaCaip2Networks.Localnet]: 'solana-localnet',
+};
+
+export class TokenMetadataClient {
+  readonly #configProvider: ConfigProvider;
+
+  readonly #fetch: typeof globalThis.fetch;
+
+  readonly #logger: ILogger;
+
+  constructor(
+    configProvider: ConfigProvider,
+    _fetch: typeof globalThis.fetch = globalThis.fetch,
+    _logger: ILogger = logger,
+  ) {
+    this.#configProvider = configProvider;
+    this.#fetch = _fetch;
+    this.#logger = _logger;
+  }
+
+  async getTokenMetadataFromAddresses(
+    addresses: string[],
+    scope: SolanaCaip2Networks,
+  ): Promise<Record<string, SolanaTokenMetadata>> {
+    try {
+      const { baseUrl, apiKey } = this.#configProvider.get().tokenApi;
+
+      const response = await this.#fetch(
+        `${baseUrl}/api/v0/fungibles/assets?fungible_ids=${addresses
+          .map(
+            (address) =>
+              // temporal fix for the token metadata client
+              // as this is going to be repalced by token api
+              // and both repsonse token address and token address should be CAIP-19
+              `${SCOPE_TO_NETWORK[scope]}.${address.split('/token:')[1]}`,
+          )
+          .join(',')}`,
+        { headers: { 'X-API-KEY': apiKey } },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = (await response.json()) as
+        | TokenMetadataResponse
+        | TokenMetadata;
+
+      const tokenMetadata = 'fungibles' in data ? data.fungibles : [data];
+
+      const tokenMetadataMap = new Map<string, SolanaTokenMetadata>();
+
+      for (const metadata of tokenMetadata) {
+        const tokenAddress = tokenAddressToCaip19(
+          scope,
+          metadata.fungible_id.split('.')[1] ?? '',
+        );
+
+        tokenMetadataMap.set(tokenAddress, {
+          name: metadata.name,
+          symbol: metadata.symbol,
+          iconUrl: `https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/${
+            metadata.fungible_id.split('.')[1]
+          }/logo.png`,
+        });
+      }
+
+      return Object.fromEntries(tokenMetadataMap);
+    } catch (error) {
+      this.#logger.error(error, 'Error fetching token metadata');
+      throw error;
+    }
+  }
+}

--- a/packages/snap/src/core/clients/token-metadata-client/types.ts
+++ b/packages/snap/src/core/clients/token-metadata-client/types.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export type TokenMetadataResponse = {
+  fungibles: TokenMetadata[];
+};
+
+export type SolanaTokenMetadata = {
+  name: string;
+  symbol: string;
+  iconUrl: string;
+};
+
+export type TokenMetadata = {
+  fungible_id: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  chain: string;
+  previews: {
+    image_small_url: string;
+    image_medium_url: string;
+    image_large_url: string;
+    image_opengraph_url: string;
+    blurhash: string;
+    predominant_color: string;
+  };
+  image_url: string;
+  image_properties: {
+    width: number;
+    height: number;
+    size: number;
+    mime_type: string;
+    exif_orientation: number | null;
+  };
+  created_date: string | null;
+  created_by: string | null;
+  supply: string;
+  holder_count: number;
+  extra_metadata: {
+    showName: boolean;
+    createdOn: string;
+    is_mutable: boolean;
+    creators: any[];
+    token_program: string;
+    extensions: any[];
+    image_original_url: string;
+    animation_original_url: string | null;
+    metadata_original_url: string;
+  };
+};

--- a/packages/snap/src/core/constants/solana.ts
+++ b/packages/snap/src/core/constants/solana.ts
@@ -1,5 +1,9 @@
+import { address } from '@solana/web3.js';
+
 /* eslint-disable no-restricted-globals */
 export const SOL_SYMBOL = 'SOL';
+export const SOL_IMAGE_URL =
+  'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png';
 
 /**
  * Solana CAIP-2 Networks
@@ -30,7 +34,7 @@ export const NETWORK_TO_EXPLORER_CLUSTER = {
 
 export enum SolanaInternalRpcMethods {
   StartSendTransactionFlow = 'startSendTransactionFlow',
-  ShowTransactionConfirmation = 'showTransactionConfirmation',
+  ListAccountAssets = 'listAccountAssets',
 }
 
 export const LAMPORTS_PER_SOL = 1_000_000_000;
@@ -56,3 +60,7 @@ export const SolanaTokens = {
 } as const satisfies Record<SolanaCaip19Tokens, TokenInfo>;
 
 export const SOL_TRANSFER_FEE_LAMPORTS = 5000;
+
+export const TOKEN_PROGRAM_ID = address(
+  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+);

--- a/packages/snap/src/core/handlers/onCronjob/index.ts
+++ b/packages/snap/src/core/handlers/onCronjob/index.ts
@@ -11,4 +11,5 @@ export enum OnCronjobMethods {
 export const handlers: Record<OnCronjobMethods, OnCronjobHandler> = {
   [OnCronjobMethods.RefreshTokenPrices]: refreshTokenPrices,
   [OnCronjobMethods.RefreshTransactions]: refreshTransactions,
+  // Register new handlers here
 };

--- a/packages/snap/src/core/handlers/onRpcRequest/index.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/index.ts
@@ -1,12 +1,13 @@
 import { type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
+import { SolanaInternalRpcMethods } from '../../constants/solana';
+import { listAccountAssets } from './listAccountAssets';
 import { renderSend } from './renderSend';
 
-export enum OnRpcRequestMethods {
-  StartSendTransactionFlow = 'startSendTransactionFlow',
-}
-
-export const handlers: Record<OnRpcRequestMethods, OnRpcRequestHandler> = {
-  [OnRpcRequestMethods.StartSendTransactionFlow]: renderSend,
+export const handlers: Partial<
+  Record<SolanaInternalRpcMethods, OnRpcRequestHandler>
+> = {
+  [SolanaInternalRpcMethods.StartSendTransactionFlow]: renderSend,
+  [SolanaInternalRpcMethods.ListAccountAssets]: listAccountAssets,
   // Register new handlers here
 };

--- a/packages/snap/src/core/handlers/onRpcRequest/listAccountAssets.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/listAccountAssets.ts
@@ -1,0 +1,13 @@
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+
+import { keyring } from '../../../snap-context';
+
+export const listAccountAssets: OnRpcRequestHandler = async ({ request }) => {
+  const { params } = request;
+
+  const { id } = params as { id: string };
+
+  const accountAssets = await keyring.listAccountAssets(id);
+
+  return accountAssets;
+};

--- a/packages/snap/src/core/services/TransactionHelper/TransactionHelper.test.ts
+++ b/packages/snap/src/core/services/TransactionHelper/TransactionHelper.test.ts
@@ -19,6 +19,7 @@ jest.mock('@solana/web3.js', () => ({
   pipe: (...fns: any[]) => fns[fns.length - 1],
   prependTransactionMessageInstructions: jest.fn().mockReturnValue({}),
   isSolanaError: jest.fn().mockReturnValue(false),
+  address: jest.fn().mockImplementation((address) => address),
 }));
 
 describe('TransactionHelper', () => {

--- a/packages/snap/src/core/services/assets.test.ts
+++ b/packages/snap/src/core/services/assets.test.ts
@@ -1,0 +1,126 @@
+import {
+  SolanaCaip19Tokens,
+  SOL_SYMBOL,
+  SolanaCaip2Networks,
+  SOL_IMAGE_URL,
+} from '../constants/solana';
+import { SOLANA_MOCK_SPL_TOKENS } from '../test/mocks/solana-assets';
+import { MOCK_SOLANA_KEYRING_ACCOUNT_1 } from '../test/mocks/solana-keyring-accounts';
+import logger from '../utils/logger';
+import { AssetsService } from './assets';
+import type { SolanaConnection } from './connection';
+import { createMockConnection } from './mocks/mockConnection';
+import { MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE } from './mocks/mockSolanaRpcResponses';
+
+jest.mock('./connection');
+jest.mock('../utils/logger');
+
+describe('AssetsService', () => {
+  let assetsService: AssetsService;
+  let mockConnection: SolanaConnection;
+
+  beforeEach(() => {
+    mockConnection = createMockConnection();
+
+    assetsService = new AssetsService({
+      connection: mockConnection,
+      logger,
+    });
+  });
+
+  describe('discoverTokens', () => {
+    it('discovers tokens with non-zero balance', async () => {
+      const { address } = MOCK_SOLANA_KEYRING_ACCOUNT_1;
+      const scope = SolanaCaip2Networks.Localnet;
+
+      const mockSend = jest.fn().mockReturnValue({
+        value: [
+          ...MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE.result.value,
+          // adding a 0 balance token to the response in purpose
+          // to test the filtering of zero balance tokens
+          {
+            account: {
+              data: {
+                parsed: {
+                  info: {
+                    mint: 'tokenAddress1',
+                    tokenAmount: {
+                      amount: '0',
+                      decimals: 6,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      const mockGetTokenAccountsByOwner = jest
+        .fn()
+        .mockReturnValue({ send: mockSend });
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getTokenAccountsByOwner: mockGetTokenAccountsByOwner,
+      } as any);
+
+      const tokens = await assetsService.discoverTokens(address, scope);
+
+      expect(tokens).toStrictEqual(
+        SOLANA_MOCK_SPL_TOKENS.map(({ metadata, ...token }) => token),
+      );
+    });
+
+    it('throws an error if the RPC call fails', async () => {
+      const { address } = MOCK_SOLANA_KEYRING_ACCOUNT_1;
+      const scope = SolanaCaip2Networks.Localnet;
+
+      const mockSend = jest.fn().mockRejectedValue(new Error('Network error'));
+      const mockGetTokenAccountsByOwner = jest
+        .fn()
+        .mockReturnValue({ send: mockSend });
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getTokenAccountsByOwner: mockGetTokenAccountsByOwner,
+      } as any);
+
+      await expect(
+        assetsService.discoverTokens(address, scope),
+      ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getNativeAsset', () => {
+    it('gets native asset', async () => {
+      const { address } = MOCK_SOLANA_KEYRING_ACCOUNT_1;
+      const scope = SolanaCaip2Networks.Localnet;
+
+      const nativeAsset = await assetsService.getNativeAsset(address, scope);
+
+      expect(nativeAsset).toStrictEqual({
+        scope,
+        address: `${scope}/${SolanaCaip19Tokens.SOL}`,
+        balance: '123456789',
+        decimals: 9,
+        native: true,
+        metadata: {
+          symbol: SOL_SYMBOL,
+          name: 'Solana',
+          iconUrl: SOL_IMAGE_URL,
+        },
+      });
+    });
+
+    it('throws an error if the RPC call fails', async () => {
+      const { address } = MOCK_SOLANA_KEYRING_ACCOUNT_1;
+      const scope = SolanaCaip2Networks.Localnet;
+
+      const mockSend = jest.fn().mockRejectedValue(new Error('Network error'));
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getBalance: jest.fn().mockReturnValue({ send: mockSend }),
+      } as any);
+
+      await expect(
+        assetsService.getNativeAsset(address, scope),
+      ).rejects.toThrow('Network error');
+    });
+  });
+});

--- a/packages/snap/src/core/services/assets.ts
+++ b/packages/snap/src/core/services/assets.ts
@@ -1,0 +1,112 @@
+import type { Balance } from '@metamask/keyring-api';
+import {
+  address as asAddress,
+  type JsonParsedTokenAccount,
+} from '@solana/web3.js';
+import { BigNumber } from 'bignumber.js';
+
+import type { SolanaCaip2Networks } from '../constants/solana';
+import {
+  SOL_IMAGE_URL,
+  SOL_SYMBOL,
+  SolanaCaip19Tokens,
+  TOKEN_PROGRAM_ID,
+} from '../constants/solana';
+import type { SolanaAsset } from '../types/solana';
+import type { ILogger } from '../utils/logger';
+import { tokenAddressToCaip19 } from '../utils/token-address-to-caip19';
+import type { SolanaConnection } from './connection';
+
+export class AssetsService {
+  readonly #logger: ILogger;
+
+  readonly #connection: SolanaConnection;
+
+  constructor({
+    connection,
+    logger,
+  }: {
+    connection: SolanaConnection;
+    logger: ILogger;
+  }) {
+    this.#logger = logger;
+    this.#connection = connection;
+  }
+
+  async discoverTokens(
+    address: string,
+    scope: SolanaCaip2Networks,
+  ): Promise<SolanaAsset[]> {
+    const tokens = await this.#getAddressTokenAccounts(address, scope);
+
+    const nonZeroBalanceTokens = this.filterZeroBalanceTokens(tokens);
+
+    return nonZeroBalanceTokens;
+  }
+
+  async getNativeAsset(
+    address: string,
+    scope: SolanaCaip2Networks,
+  ): Promise<SolanaAsset> {
+    const response = await this.#connection
+      .getRpc(scope)
+      .getBalance(asAddress(address))
+      .send();
+
+    return {
+      scope,
+      address: `${scope}/${SolanaCaip19Tokens.SOL}`,
+      balance: response.value.toString(),
+      decimals: 9,
+      native: true,
+      metadata: {
+        symbol: SOL_SYMBOL,
+        name: 'Solana',
+        iconUrl: SOL_IMAGE_URL,
+      },
+    };
+  }
+
+  filterZeroBalanceTokens(tokens: SolanaAsset[]) {
+    return tokens.filter((token) =>
+      new BigNumber(token.balance).isGreaterThan(0),
+    );
+  }
+
+  async #getAddressTokenAccounts(address: string, scope: SolanaCaip2Networks) {
+    try {
+      const response = await this.#connection
+        .getRpc(scope)
+        .getTokenAccountsByOwner(
+          asAddress(address),
+          {
+            programId: TOKEN_PROGRAM_ID,
+          },
+          {
+            encoding: 'jsonParsed',
+          },
+        )
+        .send();
+
+      return response.value.map((token) =>
+        this.#mapRpcSolanaToken(token.account.data.parsed.info, scope),
+      );
+    } catch (error) {
+      this.#logger.error(error, 'Error fetching token accounts');
+      throw error;
+    }
+  }
+
+  #mapRpcSolanaToken(
+    token: JsonParsedTokenAccount,
+    scope: SolanaCaip2Networks,
+  ): SolanaAsset {
+    return {
+      scope,
+      address: tokenAddressToCaip19(scope, token.mint),
+      balance: token.tokenAmount.amount,
+      decimals: token.tokenAmount.decimals,
+      native: token.isNative,
+    };
+  }
+}

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -17,6 +17,8 @@ const EnvStruct = object({
   RPC_URL_LOCALNET_LIST: CommaSeparatedString,
   PRICE_API_BASE_URL: string(),
   PRICE_API_BASE_URL_LOCAL: string(),
+  TOKEN_API_BASE_URL: string(),
+  TOKEN_API_KEY: string(),
   LOCAL: optional(string()),
 });
 
@@ -32,8 +34,13 @@ export type Network = {
 export type Config = {
   networks: Network[];
   isLocal: boolean;
+  activeNetworks: SolanaCaip2Networks[];
   priceApi: {
     baseUrl: string;
+  };
+  tokenApi: {
+    baseUrl: string;
+    apiKey: string;
   };
 };
 
@@ -61,8 +68,13 @@ export class ConfigProvider {
       RPC_URL_DEVNET_LIST: process.env.RPC_URL_DEVNET_LIST,
       RPC_URL_TESTNET_LIST: process.env.RPC_URL_TESTNET_LIST,
       RPC_URL_LOCALNET_LIST: process.env.RPC_URL_LOCALNET_LIST,
+      // Price API
       PRICE_API_BASE_URL: process.env.PRICE_API_BASE_URL,
       PRICE_API_BASE_URL_LOCAL: process.env.PRICE_API_BASE_URL_LOCAL,
+      // Token API
+      TOKEN_API_BASE_URL: process.env.TOKEN_API_BASE_URL,
+      TOKEN_API_KEY: process.env.TOKEN_API_KEY,
+      // TODO: Remove this once we have a better way to handle local environment
       LOCAL: process.env.LOCAL,
     };
 
@@ -99,10 +111,15 @@ export class ConfigProvider {
         },
       ],
       isLocal: Boolean(environment.LOCAL),
+      activeNetworks: [SolanaCaip2Networks.Mainnet, SolanaCaip2Networks.Devnet],
       priceApi: {
         baseUrl: environment.LOCAL
           ? environment.PRICE_API_BASE_URL_LOCAL
           : environment.PRICE_API_BASE_URL,
+      },
+      tokenApi: {
+        baseUrl: environment.TOKEN_API_BASE_URL,
+        apiKey: environment.TOKEN_API_KEY,
       },
     };
   }

--- a/packages/snap/src/core/services/connection/SolanaConnection.test.ts
+++ b/packages/snap/src/core/services/connection/SolanaConnection.test.ts
@@ -6,6 +6,7 @@ jest.mock('@solana/web3.js', () => ({
   createSolanaRpcFromTransport: jest.fn().mockImplementation((transport) => ({
     urls: transport.urls,
   })),
+  address: jest.fn().mockImplementation((address) => address),
 }));
 
 jest.mock('./transport', () => ({

--- a/packages/snap/src/core/services/mocks/mockConnection.ts
+++ b/packages/snap/src/core/services/mocks/mockConnection.ts
@@ -2,6 +2,7 @@ import type { SolanaConnection } from '../connection/SolanaConnection';
 import {
   MOCK_SOLANA_RPC_GET_BALANCE_RESPONSE,
   MOCK_SOLANA_RPC_GET_LATEST_BLOCKHASH_RESPONSE,
+  MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE,
   MOCK_SOLANA_RPC_SEND_TRANSACTION_RESPONSE,
 } from './mockSolanaRpcResponses';
 
@@ -40,9 +41,19 @@ const createMockGetTransaction = () =>
     }),
   });
 
+const createMockGetTokenAccountsByOwner = () =>
+  jest.fn().mockReturnValue({
+    send: jest
+      .fn()
+      .mockReturnValue(
+        MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE.result,
+      ),
+  });
+
 const createMockGetRpc = () =>
   jest.fn().mockReturnValue({
     getBalance: createMockGetBalance(),
+    getTokenAccountsByOwner: createMockGetTokenAccountsByOwner(),
     getLatestBlockhash: createMockGetLatestBlockhash(),
     sendTransaction: createMockSendTransaction(),
     getSignaturesForAddress: createMockGetSignaturesForAddress(),

--- a/packages/snap/src/core/services/mocks/mockSolanaRpcResponses.ts
+++ b/packages/snap/src/core/services/mocks/mockSolanaRpcResponses.ts
@@ -42,3 +42,52 @@ export const MOCK_SOLANA_RPC_SEND_TRANSACTION_RESPONSE = {
   },
   id: '0',
 };
+
+/**
+ * Sample response from the Solana RPC `getTokenAccountsByOwner` method
+ */
+export const MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE = {
+  jsonrpc: '2.0',
+  result: {
+    context: {
+      slot: 302900219,
+    },
+    value: [
+      {
+        account: {
+          data: {
+            parsed: {
+              info: {
+                mint: 'address1',
+                owner: 'owner1',
+                isNative: false,
+                tokenAmount: {
+                  amount: '123456789',
+                  decimals: 9,
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        account: {
+          data: {
+            parsed: {
+              info: {
+                mint: 'address2',
+                owner: 'owner2',
+                isNative: false,
+                tokenAmount: {
+                  amount: '987654321',
+                  decimals: 9,
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  id: '0',
+};

--- a/packages/snap/src/core/services/token-metadata.test.ts
+++ b/packages/snap/src/core/services/token-metadata.test.ts
@@ -1,0 +1,62 @@
+import type { TokenMetadataClient } from '../clients/token-metadata-client/token-metadata-client';
+import { SolanaCaip2Networks } from '../constants/solana';
+import {
+  SOLANA_MOCK_SPL_TOKENS,
+  SOLANA_MOCK_TOKEN_METADATA,
+} from '../test/mocks/solana-assets';
+import type { SolanaAsset } from '../types/solana';
+import { TokenMetadataService } from './token-metadata';
+
+describe('TokenMetadataService', () => {
+  let tokenMetadataClient: TokenMetadataClient;
+  let tokenMetadataService: TokenMetadataService;
+
+  beforeEach(() => {
+    tokenMetadataClient = {
+      getTokenMetadataFromAddresses: jest.fn(),
+    } as unknown as TokenMetadataClient;
+
+    tokenMetadataService = new TokenMetadataService({ tokenMetadataClient });
+  });
+
+  describe('getMultipleTokenMetadata', () => {
+    it('returns an empty object if no tokens are provided', async () => {
+      const result = await tokenMetadataService.getMultipleTokenMetadata(
+        [],
+        SolanaCaip2Networks.Localnet,
+      );
+      expect(result).toStrictEqual({});
+    });
+
+    it('returns token metadata from client', async () => {
+      const tokens: SolanaAsset[] = SOLANA_MOCK_SPL_TOKENS;
+      const scope: SolanaCaip2Networks = SolanaCaip2Networks.Localnet;
+      const mockMetadata = SOLANA_MOCK_TOKEN_METADATA;
+
+      jest
+        .spyOn(tokenMetadataClient, 'getTokenMetadataFromAddresses')
+        .mockResolvedValue(mockMetadata);
+
+      const result = await tokenMetadataService.getMultipleTokenMetadata(
+        tokens,
+        scope,
+      );
+
+      expect(result).toStrictEqual(mockMetadata);
+    });
+
+    it('throws an error if the client fails to fetch token metadata', async () => {
+      const tokens: SolanaAsset[] = SOLANA_MOCK_SPL_TOKENS;
+      const scope: SolanaCaip2Networks = SolanaCaip2Networks.Localnet;
+      const error = new Error('Error fetching token metadata');
+
+      jest
+        .spyOn(tokenMetadataClient, 'getTokenMetadataFromAddresses')
+        .mockRejectedValue(error);
+
+      await expect(
+        tokenMetadataService.getMultipleTokenMetadata(tokens, scope),
+      ).rejects.toThrow('Error fetching token metadata');
+    });
+  });
+});

--- a/packages/snap/src/core/services/token-metadata.ts
+++ b/packages/snap/src/core/services/token-metadata.ts
@@ -1,0 +1,32 @@
+import type { TokenMetadataClient } from '../clients/token-metadata-client/token-metadata-client';
+import type { SolanaCaip2Networks } from '../constants/solana';
+import type { SolanaAsset } from '../types/solana';
+
+export class TokenMetadataService {
+  readonly #tokenMetadataClient: TokenMetadataClient;
+
+  constructor({
+    tokenMetadataClient,
+  }: {
+    tokenMetadataClient: TokenMetadataClient;
+  }) {
+    this.#tokenMetadataClient = tokenMetadataClient;
+  }
+
+  async getMultipleTokenMetadata(
+    tokens: SolanaAsset[],
+    scope: SolanaCaip2Networks,
+  ) {
+    if (tokens.length === 0) {
+      return {};
+    }
+
+    const tokenMetadata =
+      await this.#tokenMetadataClient.getTokenMetadataFromAddresses(
+        tokens.map((token) => token.address),
+        scope,
+      );
+
+    return tokenMetadata;
+  }
+}

--- a/packages/snap/src/core/test/mocks/solana-assets.ts
+++ b/packages/snap/src/core/test/mocks/solana-assets.ts
@@ -1,0 +1,70 @@
+import type { SolanaTokenMetadata } from '../../clients/token-metadata-client/types';
+import {
+  SolanaCaip19Tokens,
+  SolanaCaip2Networks,
+} from '../../constants/solana';
+import type { SolanaAsset } from '../../types/solana';
+
+export const SOLANA_MOCK_TOKEN: SolanaAsset = {
+  scope: SolanaCaip2Networks.Localnet,
+  address: `${SolanaCaip2Networks.Localnet}/${SolanaCaip19Tokens.SOL}`,
+  balance: '123456789',
+  decimals: 9,
+  native: true,
+  metadata: {
+    iconUrl:
+      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/sol/logo.png',
+    name: 'Solana',
+    symbol: 'SOL',
+  },
+};
+
+export const SOLANA_MOCK_SPL_TOKENS: SolanaAsset[] = [
+  {
+    scope: SolanaCaip2Networks.Localnet,
+    address: `${SolanaCaip2Networks.Localnet}/token:address1`,
+    balance: '123456789',
+    decimals: 9,
+    native: false,
+    metadata: {
+      iconUrl:
+        'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address1/logo.png',
+      name: 'Mock Token 1',
+      symbol: 'MOCK1',
+    },
+  },
+  {
+    scope: SolanaCaip2Networks.Localnet,
+    address: `${SolanaCaip2Networks.Localnet}/token:address2`,
+    balance: '987654321',
+    decimals: 9,
+    native: false,
+    metadata: {
+      iconUrl:
+        'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address2/logo.png',
+      name: 'Mock Token 2',
+      symbol: 'MOCK2',
+    },
+  },
+];
+
+export const SOLANA_MOCK_TOKEN_METADATA: Record<string, SolanaTokenMetadata> = {
+  [SOLANA_MOCK_TOKEN.address]: {
+    iconUrl:
+      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/sol/logo.png',
+    name: 'Solana',
+    symbol: 'SOL',
+  },
+  [`${SolanaCaip2Networks.Localnet}/token:address1`]: {
+    iconUrl:
+      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address1/logo.png',
+    name: 'Mock Token 1',
+    symbol: 'MOCK1',
+  },
+  [`${SolanaCaip2Networks.Localnet}/token:address2`]: {
+    iconUrl:
+      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/address2/logo.png',
+    name: 'Mock Token 2',
+    symbol: 'MOCK2',
+  },
+};

--- a/packages/snap/src/core/types/solana.ts
+++ b/packages/snap/src/core/types/solana.ts
@@ -12,6 +12,18 @@ import type {
   UnixTimestamp,
 } from '@solana/web3.js';
 
+import type { SolanaTokenMetadata } from '../clients/token-metadata-client/types';
+import type { SolanaCaip2Networks } from '../constants/solana';
+
+export type SolanaAsset = {
+  scope: SolanaCaip2Networks;
+  address: string;
+  balance: string;
+  decimals: number;
+  native: boolean;
+  metadata?: SolanaTokenMetadata;
+};
+
 export type SolanaInstruction = {
   accounts: readonly number[];
   data: Base58EncodedBytes;

--- a/packages/snap/src/core/utils/get-network-from-token.ts
+++ b/packages/snap/src/core/utils/get-network-from-token.ts
@@ -1,9 +1,11 @@
+import type { SolanaCaip2Networks } from '../constants/solana';
+
 /**
  * Extracts the network identifier from a CAIP-19 token string.
  *
  * @param caip19Token - The CAIP-19 token string, which is expected to be in the format 'network/token'.
  * @returns The network identifier extracted from the CAIP-19 token string.
  */
-export function getNetworkFromToken(caip19Token: string) {
-  return caip19Token.split('/')[0];
+export function getNetworkFromToken(caip19Token: string): SolanaCaip2Networks {
+  return caip19Token.split('/')[0] as SolanaCaip2Networks;
 }

--- a/packages/snap/src/core/utils/parse-units.ts
+++ b/packages/snap/src/core/utils/parse-units.ts
@@ -1,0 +1,19 @@
+import { BigNumber } from 'bignumber.js';
+
+/**
+ * Parses a string amount into units based on the provided decimals.
+ *
+ * @param amount - The amount to be parsed.
+ * @param decimals - The number of decimal places.
+ * @returns The parsed amount in units.
+ */
+export function parseUnits(
+  amount: string | BigNumber,
+  decimals: number,
+): string {
+  const amountBigNumber = new BigNumber(amount);
+  const divisor = new BigNumber(10).pow(decimals);
+  const amountUnits = amountBigNumber.div(divisor);
+
+  return amountUnits.toString();
+}

--- a/packages/snap/src/core/utils/token-address-to-caip19.ts
+++ b/packages/snap/src/core/utils/token-address-to-caip19.ts
@@ -1,0 +1,15 @@
+import type { SolanaCaip2Networks } from '../constants/solana';
+
+/**
+ * Converts a token address to a CAIP-19 identifier.
+ *
+ * @param scope - The network scope.
+ * @param address - The token address.
+ * @returns The CAIP-19 identifier.
+ */
+export function tokenAddressToCaip19(
+  scope: SolanaCaip2Networks,
+  address: string,
+): string {
+  return `${scope}/token:${address}`;
+}

--- a/packages/snap/src/core/validation/structs.ts
+++ b/packages/snap/src/core/validation/structs.ts
@@ -1,19 +1,5 @@
 import type { Infer } from 'superstruct';
-import {
-  enums,
-  number,
-  object,
-  pattern,
-  record,
-  refine,
-  string,
-} from 'superstruct';
-
-import {
-  SOL_SYMBOL,
-  SolanaCaip19Tokens,
-  SolanaCaip2Networks,
-} from '../constants/solana';
+import { number, object, pattern, record, refine, string } from 'superstruct';
 
 export const PositiveNumber = refine(number(), 'positive', (value) => {
   if (value < 0) {
@@ -28,20 +14,19 @@ export const PositiveNumberStringStruct = pattern(
 );
 
 /**
- * Validates a Solana asset string, for instance
+ * Validates a CAIP-19 asset identifier string, for instance
  * "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
  */
-export const AssetsStruct = enums(
-  Object.values(SolanaCaip2Networks).map(
-    (network) => `${network}/${SolanaCaip19Tokens.SOL}`,
-  ),
+export const Caip19Struct = pattern(
+  string(),
+  /^[-a-z0-9]{3,8}:[-a-zA-Z0-9]{1,64}\/[-a-zA-Z0-9]{1,64}(:[-a-zA-Z0-9]{1,64})?$/u,
 );
 
 export const GetAccounBalancesResponseStruct = record(
-  AssetsStruct,
+  Caip19Struct,
   object({
     amount: PositiveNumberStringStruct,
-    unit: enums([SOL_SYMBOL as string]),
+    unit: string(),
   }),
 );
 

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -11,14 +11,12 @@ import {
   type OnRpcRequestHandler,
 } from '@metamask/snaps-sdk';
 
+import { SolanaInternalRpcMethods } from './core/constants/solana';
 import {
   handlers as onCronjobHandlers,
   OnCronjobMethods,
 } from './core/handlers/onCronjob';
-import {
-  handlers as onRpcRequestHandlers,
-  OnRpcRequestMethods,
-} from './core/handlers/onRpcRequest';
+import { handlers as onRpcRequestHandlers } from './core/handlers/onRpcRequest';
 import { install as installPolyfills } from './core/polyfills';
 import { isSnapRpcError } from './core/utils/errors';
 import logger from './core/utils/logger';
@@ -48,12 +46,12 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
 
     validateOrigin(origin, method);
 
-    const handler = onRpcRequestHandlers[method as OnRpcRequestMethods];
+    const handler = onRpcRequestHandlers[method as SolanaInternalRpcMethods];
 
     if (!handler) {
       throw new MethodNotFoundError(
         `RpcRequest method ${method} not found. Available methods: ${Object.values(
-          OnRpcRequestMethods,
+          SolanaInternalRpcMethods,
         ).toString()}`,
       ) as unknown as Error;
     }

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -14,6 +14,7 @@ const dappPermissions = new Set([
   KeyringRpcMethod.ListAccountTransactions,
   // RPC methods
   SolanaInternalRpcMethods.StartSendTransactionFlow,
+  SolanaInternalRpcMethods.ListAccountAssets,
 ]);
 
 const metamaskPermissions = new Set([
@@ -27,6 +28,7 @@ const metamaskPermissions = new Set([
   KeyringRpcMethod.ListAccountTransactions,
   // RPC methods
   SolanaInternalRpcMethods.StartSendTransactionFlow,
+  SolanaInternalRpcMethods.ListAccountAssets,
 ]);
 
 const allowedOrigins = [

--- a/packages/snap/src/snap-context.ts
+++ b/packages/snap/src/snap-context.ts
@@ -1,9 +1,12 @@
 import { PriceApiClient } from './core/clients/price-api/price-api-client';
+import { TokenMetadataClient } from './core/clients/token-metadata-client/token-metadata-client';
+import { AssetsService } from './core/services/assets';
 import { ConfigProvider } from './core/services/config';
 import { SolanaConnection } from './core/services/connection/SolanaConnection';
 import { EncryptedSolanaState } from './core/services/encrypted-state';
 import { SolanaKeyring } from './core/services/keyring';
 import { SolanaState } from './core/services/state';
+import { TokenMetadataService } from './core/services/token-metadata';
 import { TokenPricesService } from './core/services/TokenPricesService';
 import { TransactionHelper } from './core/services/TransactionHelper/TransactionHelper';
 import { TransactionsService } from './core/services/transactions';
@@ -21,6 +24,7 @@ export type SnapExecutionContext = {
   priceApiClient: PriceApiClient;
   encryptedState: EncryptedSolanaState;
   state: SolanaState;
+  assetsService: AssetsService;
   tokenPricesService: TokenPricesService;
   transactionHelper: TransactionHelper;
   transactionsService: TransactionsService;
@@ -37,19 +41,33 @@ const transferSolHelper = new TransferSolHelper(
   connection,
   logger,
 );
+const tokenMetadataClient = new TokenMetadataClient(configProvider);
+const priceApiClient = new PriceApiClient(configProvider);
+
 const transactionsService = new TransactionsService({
   logger,
   connection,
 });
-const priceApiClient = new PriceApiClient(configProvider);
+
+const assetsService = new AssetsService({
+  connection,
+  logger,
+});
+
+const tokenMetadataService = new TokenMetadataService({
+  tokenMetadataClient,
+});
 
 const keyring = new SolanaKeyring({
   state,
   encryptedState,
+  configProvider,
   connection,
   transactionsService,
   transferSolHelper,
   logger,
+  assetsService,
+  tokenMetadataService,
 });
 
 const tokenPricesService = new TokenPricesService(
@@ -66,6 +84,7 @@ const snapContext: SnapExecutionContext = {
   encryptedState,
   state,
   /* Services */
+  assetsService,
   tokenPricesService,
   transactionHelper,
   transactionsService,
@@ -81,7 +100,7 @@ export {
   tokenPricesService,
   transactionHelper,
   transactionsService,
-  transferSolHelper,
+  assetsService,
 };
 
 export default snapContext;


### PR DESCRIPTION
* Implements `listAccountAssets`
* Gets native balance onchain
* Gets token balances onchain
* Gets token metadata from simplehash (only for completing `unit`)
* Adds `TOKEN_API_BASE_URL` and `TOKEN_API_KEY` to the configuration