### PR TITLE
[Don't delete me] feat: implement Solana RPC rate limit handling logic

### DIFF
--- a/packages/site/src/components/AccountDetails/AccountDetails.tsx
+++ b/packages/site/src/components/AccountDetails/AccountDetails.tsx
@@ -118,19 +118,22 @@ export const AccountDetails = ({ accountId }: { accountId: string }) => {
   }, []);
 
   const accountBalances: Record<string, Balance> = useMemo(() => {
-    return Object.keys(selectedAccountBalances).reduce((list, assetId) => {
-      const assetNetwork = assetId.split('/')[0] as Network;
-      const asset = selectedAccountBalances[assetId];
+    return Object.keys(selectedAccountBalances ?? {}).reduce(
+      (list, assetId) => {
+        const assetNetwork = assetId.split('/')[0] as Network;
+        const asset = selectedAccountBalances[assetId];
 
-      if (assetNetwork !== network) {
-        return list;
-      }
+        if (assetNetwork !== network) {
+          return list;
+        }
 
-      return {
-        ...list,
-        [assetId]: asset,
-      };
-    }, {});
+        return {
+          ...list,
+          [assetId]: asset,
+        };
+      },
+      {},
+    );
   }, [network, selectedAccountBalances]);
 
   if (!selectedAccount) {

--- a/packages/site/src/context/network.tsx
+++ b/packages/site/src/context/network.tsx
@@ -20,7 +20,7 @@ export const NetworkProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [network, setNetwork] = useState<Network>(Network.Devnet);
+  const [network, setNetwork] = useState<Network>(Network.Mainnet);
 
   return (
     <NetworkContext.Provider value={{ network, setNetwork }}>

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -45,7 +45,7 @@
     "@metamask/keyring-api": "^13.0.0",
     "@metamask/keyring-snap-sdk": "^1.1.0",
     "@metamask/snaps-cli": "^6.2.1",
-    "@metamask/snaps-jest": "8.8.1",
+    "@metamask/snaps-jest": "^8.9.0",
     "@metamask/snaps-sdk": "^6.13.0",
     "@metamask/utils": "^11.0.0",
     "@noble/ed25519": "^2.1.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "+vZ+BFOUNCGVCHkKjTVhiOysgeyEOhxtUoxkN3SS4xk=",
+    "shasum": "7Vxha6vIv+EL58RyCMV6LwRewl+luNtBGK2AoecCejo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onRpcRequest/renderSend.test.tsx
+++ b/packages/snap/src/core/handlers/onRpcRequest/renderSend.test.tsx
@@ -87,7 +87,7 @@ describe('Send', () => {
     mockSolanaRpc.shutdown();
   });
 
-  it.skip('renders the send form', async () => {
+  it('renders the send form', async () => {
     const { mockResolvedResult, server } = mockSolanaRpc;
 
     // temporary mock for the token prices
@@ -105,7 +105,8 @@ describe('Send', () => {
       },
     );
 
-    const { request, mockJsonRpc } = await installSnap();
+    const installedSnap = await installSnap();
+    const { request, mockJsonRpc } = installedSnap;
 
     mockJsonRpc({
       method: 'snap_manageState',
@@ -141,10 +142,8 @@ describe('Send', () => {
       },
     });
 
-    // tmp mocking the delay: jest is going too fast (balances are not reached)
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    const screen1 = await response.getInterface();
+    const screen0 = await response.getInterface();
+    const screen1 = await screen0.waitForUpdate();
 
     const updatedContext1: SendContext = mockContext;
 

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -39,6 +39,11 @@ export type Config = {
     baseUrl: string;
     apiKey: string;
   };
+  transactions: {
+    bootstrapLimit: number;
+    storageLimit: number;
+    fetchLimit: number;
+  };
 };
 
 /**
@@ -109,6 +114,11 @@ export class ConfigProvider {
       tokenApi: {
         baseUrl: environment.TOKEN_API_BASE_URL,
         apiKey: environment.TOKEN_API_KEY,
+      },
+      transactions: {
+        bootstrapLimit: 10,
+        storageLimit: 40,
+        fetchLimit: 10,
       },
     };
   }

--- a/packages/snap/src/core/services/mocks/address.ts
+++ b/packages/snap/src/core/services/mocks/address.ts
@@ -1,0 +1,17 @@
+export const SOLANA_MOCK_ADDRESSES = [
+  'MJKqp326RZCHnAAbew9MDdui3iCKWco7fsK9sVuZTX2',
+  '52C9T2T7JRojtxumYnYZhyUmrN7kqzvCLc4Ksvjk7TxD',
+  '8BseXT9EtoEhBTKFFYkwTnjKSUZwhtmdKY2Jrj8j45Rt',
+  'GitYucwpNcg6Dx1Y15UQ9TQn8LZMX1uuqQNn8rXxEWNC',
+  '9QgXqrgdbVU8KcpfskqJpAXKzbaYQJecgMAruSWoXDkM',
+  '9uRJ5aGgeu2i3J98hsC5FDxd2PmRjVy9fQwNAy7fzLG3',
+  'EJRJswH9LyjhAfBWwPBvat1LQtrJYK4sVUzsea889cQt',
+  '53nHsQXkzZUp5MF1BK6Qoa48ud3aXfDFJBbe1oECPucC',
+  '8PjJTv657aeN9p5R2WoM6pPSz385chvTTytUWaEjSjkq',
+  'AHB94zKUASftTdqgdfiDSdnPJHkEFp7zX3yMrcSxABsv',
+  '3D91zLQPRLamwJfGR5ZYMKQb4C18gsJNaSdmB6b2wLhw',
+  'AogcwQ1ubM76EPMhSD5cw1ES4W5econvQCFmBL6nTW1',
+  '3bHbMa5VW3np5AJazuacidrN4xPZgwhcXigmjwHmBg5e',
+  'AYgECURrvuX6GtFe4tX7aAj87Xc5r5Znx96ntNk1nCv',
+  'Hc36Wh1ZqYGzGAnsJWNT9r2gY3h9n89uDpxZPsmEsiE3',
+];

--- a/packages/snap/src/core/services/transactions/Transactions.test.ts
+++ b/packages/snap/src/core/services/transactions/Transactions.test.ts
@@ -1,0 +1,28 @@
+import { transactionsService } from '../../../snapContext';
+import type { SolanaConnection } from '../connection';
+import { TransactionHelper } from '../transaction-helper/TransactionHelper';
+
+describe('TransactionsService', () => {
+  const mockRpcResponse = {
+    send: jest.fn(),
+  };
+
+  const mockConnection = {
+    getRpc: jest.fn().mockReturnValue({
+      getSignaturesForAddress: () => mockGetSignaturesResponse,
+      getTransaction: () => mockGetTransactionResponse,
+    }),
+  } as unknown as SolanaConnection;
+
+  let transactionHelper: TransactionHelper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transactionHelper = new TransactionHelper(mockConnection, logger);
+  });
+
+  it('should fetch initial transactions', async () => {
+    const transactions =
+      await transactionsService.fetchInitialAddressTransactions('123');
+  });
+});

--- a/packages/snap/src/core/services/transactions/Transactions.ts
+++ b/packages/snap/src/core/services/transactions/Transactions.ts
@@ -2,6 +2,7 @@ import type { Transaction } from '@metamask/keyring-api';
 import type { Address, Signature } from '@solana/web3.js';
 import BigNumber from 'bignumber.js';
 
+import { configProvider } from '../../../snapContext';
 import {
   LAMPORTS_PER_SOL,
   Network,
@@ -31,13 +32,14 @@ export class TransactionsService {
   }
 
   async fetchInitialAddressTransactions(address: Address) {
-    const scopes = [Network.Mainnet, Network.Devnet];
+    // const scopes = [Networ k.Mainnet, Network.Devnet];
+    const scopes = [Network.Mainnet];
 
     const transactions = (
       await Promise.all(
         scopes.map(async (scope) =>
           this.fetchAddressTransactions(scope, address, {
-            limit: 5,
+            limit: configProvider.get().transactions.bootstrapLimit,
           }),
         ),
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,9 +4400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^9.15.0":
-  version: 9.15.0
-  resolution: "@metamask/snaps-controllers@npm:9.15.0"
+"@metamask/snaps-controllers@npm:^9.16.0":
+  version: 9.16.0
+  resolution: "@metamask/snaps-controllers@npm:9.16.0"
   dependencies:
     "@metamask/approval-controller": ^7.1.1
     "@metamask/base-controller": ^7.0.2
@@ -4415,9 +4415,9 @@ __metadata:
     "@metamask/post-message-stream": ^8.1.1
     "@metamask/rpc-errors": ^7.0.1
     "@metamask/snaps-registry": ^3.2.2
-    "@metamask/snaps-rpc-methods": ^11.7.0
-    "@metamask/snaps-sdk": ^6.13.0
-    "@metamask/snaps-utils": ^8.6.1
+    "@metamask/snaps-rpc-methods": ^11.8.0
+    "@metamask/snaps-sdk": ^6.14.0
+    "@metamask/snaps-utils": ^8.7.0
     "@metamask/utils": ^10.0.0
     "@xstate/fsm": ^2.0.0
     browserify-zlib: ^0.2.0
@@ -4431,50 +4431,50 @@ __metadata:
     semver: ^7.5.4
     tar-stream: ^3.1.7
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^6.10.0
+    "@metamask/snaps-execution-environments": ^6.11.0
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: bc555442c615850e4eae3f72125f2a1a51b69eeff2e2feab7628ef8b296e1ac3048d04db94d9053c3e4de02ca42244854ce7c4625ebeb1925fa2ac0e9102de97
+  checksum: e63806dae3d8714eed4470442f91f39883d1234eacfdbfff30577f5e3ad39b7a3942f631e7b38d39eb0c8cf28c33d8fe3c77b77a3693a283fa4084612585f70c
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^6.10.0":
-  version: 6.10.0
-  resolution: "@metamask/snaps-execution-environments@npm:6.10.0"
+"@metamask/snaps-execution-environments@npm:^6.11.0":
+  version: 6.11.0
+  resolution: "@metamask/snaps-execution-environments@npm:6.11.0"
   dependencies:
     "@metamask/json-rpc-engine": ^10.0.1
     "@metamask/object-multiplex": ^2.0.0
     "@metamask/post-message-stream": ^8.1.1
     "@metamask/providers": ^18.1.1
     "@metamask/rpc-errors": ^7.0.1
-    "@metamask/snaps-sdk": ^6.11.0
-    "@metamask/snaps-utils": ^8.6.0
+    "@metamask/snaps-sdk": ^6.14.0
+    "@metamask/snaps-utils": ^8.7.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^10.0.0
     nanoid: ^3.1.31
     readable-stream: ^3.6.2
-  checksum: c39f60ad3ff0d0728b5da7fe0a11bc84b39dcbc7eba7225d96a94cb3cdfed2eb267d30fa01f815faeb184710b93551bba38be78564bf5710a4bb9ce16fe7df66
+  checksum: efa826ed86ff61c66249fe831c9ff7b86732b02dd67b3cc6dede8588be8280ddc4f207b94586602ae54f2ea3834112028e70f982c336c7f291f8795c0e233469
   languageName: node
   linkType: hard
 
-"@metamask/snaps-jest@npm:8.8.1":
-  version: 8.8.1
-  resolution: "@metamask/snaps-jest@npm:8.8.1"
+"@metamask/snaps-jest@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "@metamask/snaps-jest@npm:8.9.0"
   dependencies:
     "@jest/environment": ^29.5.0
     "@jest/expect": ^29.5.0
     "@jest/globals": ^29.5.0
-    "@metamask/snaps-controllers": ^9.15.0
-    "@metamask/snaps-sdk": ^6.13.0
-    "@metamask/snaps-simulation": ^1.4.1
+    "@metamask/snaps-controllers": ^9.16.0
+    "@metamask/snaps-sdk": ^6.14.0
+    "@metamask/snaps-simulation": ^1.5.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^10.0.0
     express: ^4.18.2
     jest-environment-node: ^29.5.0
     jest-matcher-utils: ^29.5.0
     redux: ^4.2.1
-  checksum: b57e25469f50c5d6594cefb63dfacd02de85c7718bdeb750245f2c7c63e4660e51ce21fe9d2bf62626a8ffd4106d6fb24f4eef829caca5fb02ccc77cd6855c70
+  checksum: 52e89585ca5987bae9da8d9be52b6828f99cb413978c4b76aecc5dbcb9929886107eaf9d2f13cdaf15413d36de9fcea07148ed1dbe30341743ca297b31eb9867
   languageName: node
   linkType: hard
 
@@ -4502,32 +4502,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^11.7.0":
-  version: 11.7.0
-  resolution: "@metamask/snaps-rpc-methods@npm:11.7.0"
+"@metamask/snaps-rpc-methods@npm:^11.8.0":
+  version: 11.8.0
+  resolution: "@metamask/snaps-rpc-methods@npm:11.8.0"
   dependencies:
     "@metamask/key-tree": ^10.0.1
     "@metamask/permission-controller": ^11.0.3
     "@metamask/rpc-errors": ^7.0.1
-    "@metamask/snaps-sdk": ^6.13.0
-    "@metamask/snaps-utils": ^8.6.1
+    "@metamask/snaps-sdk": ^6.14.0
+    "@metamask/snaps-utils": ^8.7.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^10.0.0
     "@noble/hashes": ^1.3.1
-  checksum: 2b2cb08e87ea7fdb4ba0d948316d1584365b9804504ea4a9350f554d5d639884148ca89b8c1991469b84a9b4f6e7ef9b7b7701d65381f1d342344b7608834176
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-sdk@npm:^6.11.0, @metamask/snaps-sdk@npm:^6.5.0, @metamask/snaps-sdk@npm:^6.9.0":
-  version: 6.12.0
-  resolution: "@metamask/snaps-sdk@npm:6.12.0"
-  dependencies:
-    "@metamask/key-tree": ^9.1.2
-    "@metamask/providers": ^18.1.1
-    "@metamask/rpc-errors": ^7.0.1
-    "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^10.0.0
-  checksum: 878dde330e161ee1eaa01a87899e9e1ea8c88561bfd20bc827c337271baf2748d9bdbad53e1eddf210325e9c8187f4585798118995fa725b1b8d8c4f4c53d821
+  checksum: 397a7899153045504ccb61a779b8e63f29ca13ad63abdf6e6eb9e9c2aed1032a95ec3ebab095bf65a95b24f60ac5f4711e247aa05b4c49a962d9a729b472882c
   languageName: node
   linkType: hard
 
@@ -4544,9 +4531,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-simulation@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@metamask/snaps-simulation@npm:1.4.1"
+"@metamask/snaps-sdk@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "@metamask/snaps-sdk@npm:6.14.0"
+  dependencies:
+    "@metamask/key-tree": ^10.0.1
+    "@metamask/providers": ^18.1.1
+    "@metamask/rpc-errors": ^7.0.1
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^10.0.0
+  checksum: b3249976538664f9bf40b5bedc307c42940fb105e2e292f38668853d581ebcedf274978dbe4af331383f743ed87ee587c0e3e5eac834765aefa199920d86b898
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-sdk@npm:^6.5.0, @metamask/snaps-sdk@npm:^6.9.0":
+  version: 6.12.0
+  resolution: "@metamask/snaps-sdk@npm:6.12.0"
+  dependencies:
+    "@metamask/key-tree": ^9.1.2
+    "@metamask/providers": ^18.1.1
+    "@metamask/rpc-errors": ^7.0.1
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^10.0.0
+  checksum: 878dde330e161ee1eaa01a87899e9e1ea8c88561bfd20bc827c337271baf2748d9bdbad53e1eddf210325e9c8187f4585798118995fa725b1b8d8c4f4c53d821
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-simulation@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@metamask/snaps-simulation@npm:1.5.0"
   dependencies:
     "@metamask/base-controller": ^7.0.2
     "@metamask/eth-json-rpc-middleware": ^15.0.0
@@ -4555,18 +4568,19 @@ __metadata:
     "@metamask/key-tree": ^10.0.1
     "@metamask/permission-controller": ^11.0.3
     "@metamask/phishing-controller": ^12.0.2
-    "@metamask/snaps-controllers": ^9.15.0
-    "@metamask/snaps-execution-environments": ^6.10.0
-    "@metamask/snaps-rpc-methods": ^11.7.0
-    "@metamask/snaps-sdk": ^6.13.0
-    "@metamask/snaps-utils": ^8.6.1
+    "@metamask/snaps-controllers": ^9.16.0
+    "@metamask/snaps-execution-environments": ^6.11.0
+    "@metamask/snaps-rpc-methods": ^11.8.0
+    "@metamask/snaps-sdk": ^6.14.0
+    "@metamask/snaps-utils": ^8.7.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^10.0.0
     "@reduxjs/toolkit": ^1.9.5
+    fast-deep-equal: ^3.1.3
     mime: ^3.0.0
     readable-stream: ^3.6.2
     redux-saga: ^1.2.3
-  checksum: 41a45f3dbf1b58166171dc0bc55c2b9a9a17fb3583412113b92903ce6e200012715f838aefa3af3b6d04a85d1d815c39fc39a3f98dba0f831dd0b188465692b1
+  checksum: 03baf08841b51ca56f67ead16b41e69830bb20663cbd5fe83ee0a9e8068f9dbd80fe5e6dfdb0966a19c85efc0cc6c98d3f681c5b7f56bbd929f8c379dfebaf06
   languageName: node
   linkType: hard
 
@@ -4601,40 +4615,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@metamask/snaps-utils@npm:8.6.0"
-  dependencies:
-    "@babel/core": ^7.23.2
-    "@babel/types": ^7.23.0
-    "@metamask/base-controller": ^7.0.2
-    "@metamask/key-tree": ^9.1.2
-    "@metamask/permission-controller": ^11.0.3
-    "@metamask/rpc-errors": ^7.0.1
-    "@metamask/slip44": ^4.0.0
-    "@metamask/snaps-registry": ^3.2.2
-    "@metamask/snaps-sdk": ^6.11.0
-    "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^10.0.0
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.1
-    chalk: ^4.1.2
-    cron-parser: ^4.5.0
-    fast-deep-equal: ^3.1.3
-    fast-json-stable-stringify: ^2.1.0
-    fast-xml-parser: ^4.4.1
-    marked: ^12.0.1
-    rfdc: ^1.3.0
-    semver: ^7.5.4
-    ses: ^1.1.0
-    validate-npm-package-name: ^5.0.0
-  checksum: 65f5ce507ee820959ead9c056025f82ea8c3d65a9539f5af08c9fcf4052d2109b29df24c2b5781aaea65c3e5db2d0063eb5a0ba958ea3cfabb9f49db1fa20e80
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:^8.6.1":
-  version: 8.6.1
-  resolution: "@metamask/snaps-utils@npm:8.6.1"
+"@metamask/snaps-utils@npm:^8.7.0":
+  version: 8.7.0
+  resolution: "@metamask/snaps-utils@npm:8.7.0"
   dependencies:
     "@babel/core": ^7.23.2
     "@babel/types": ^7.23.0
@@ -4644,7 +4627,7 @@ __metadata:
     "@metamask/rpc-errors": ^7.0.1
     "@metamask/slip44": ^4.0.0
     "@metamask/snaps-registry": ^3.2.2
-    "@metamask/snaps-sdk": ^6.13.0
+    "@metamask/snaps-sdk": ^6.14.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^10.0.0
     "@noble/hashes": ^1.3.1
@@ -4659,7 +4642,7 @@ __metadata:
     semver: ^7.5.4
     ses: ^1.1.0
     validate-npm-package-name: ^5.0.0
-  checksum: 762ccfd5ebf51fa18041dd83cfcc65ed1b7b5ea299accddde86a870ec6b888ee9ff446861590f85331c9e535c2b189aabd95d7ecca6ed48deada1a4b83063b42
+  checksum: 3f8a8ffd923a80da0056fd97b4ae60dffeae096ce35f855a1e2dea2cd447027325a763f8350c9110a2eca3c3ebe030be9c1789da5b2a58e14a6f85a298b54bb0
   languageName: node
   linkType: hard
 
@@ -4686,7 +4669,7 @@ __metadata:
     "@metamask/keyring-api": ^13.0.0
     "@metamask/keyring-snap-sdk": ^1.1.0
     "@metamask/snaps-cli": ^6.2.1
-    "@metamask/snaps-jest": 8.8.1
+    "@metamask/snaps-jest": ^8.9.0
     "@metamask/snaps-sdk": ^6.13.0
     "@metamask/utils": ^11.0.0
     "@noble/ed25519": ^2.1.0


### PR DESCRIPTION
For now this PR only includes a testing ground for different rate limits on mainnet by mocking the Solana account generation to use whales' addresses with transactions