### PR TITLE
fix: disregard emitting updates for transactions which has no `from` or `to` fields 

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "jZV88kpBH20ePGrQpBLmhmioxxMzhsd3PojyGJaFIKg=",
+    "shasum": "6y42sdG8PY31XMSdzyicAPJv21+IVikjQUxXLgJcV1U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onCronjob/refreshTransactions.ts
+++ b/packages/snap/src/core/handlers/onCronjob/refreshTransactions.ts
@@ -180,7 +180,12 @@ async function fetchAndMapTransactionsPerAccount({
             account: account.id,
           };
         })
-        .filter((tx): tx is Transaction => tx !== null);
+        .filter(
+          (tx): tx is Transaction =>
+            // if there is no changes with the transaction, don't emit the event
+            // example: when sending SOL to the same account.
+            tx !== null && tx.from.length > 0 && tx.to.length > 0,
+        );
 
       newTransactions[account.id]?.push(...accountTransactions);
     }

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -210,6 +210,15 @@ export class WalletService {
         account: account.id,
       } as Transaction;
 
+      // if there is no changes with the transaction, don't emit the event
+      // example: when sending SOL to the same account.
+      if (
+        mappedTransactionWithAccountId?.from?.length === 0 &&
+        mappedTransactionWithAccountId?.to?.length === 0
+      ) {
+        return result;
+      }
+
       await emitSnapKeyringEvent(
         snap,
         KeyringEvent.AccountTransactionsUpdated,


### PR DESCRIPTION
* disregard emitting updates for transactions which has no `from` or `to` fields 