### PR TITLE
feat: forward `MetaMaskOptions` in `keyring_createAccount` method

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.0.2",
     "@emotion/react": "^11.13.3",
-    "@metamask/keyring-api": "^17.2.1",
+    "@metamask/keyring-api": "^17.3.0",
     "@metamask/providers": "^18.1.0",
     "@solana-program/compute-budget": "^0.7.0",
     "@solana-program/system": "^0.7.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -41,7 +41,7 @@
     "@jest/globals": "^29.5.0",
     "@metamask/auto-changelog": "4.0.0",
     "@metamask/key-tree": "9.1.2",
-    "@metamask/keyring-api": "17.2.1",
+    "@metamask/keyring-api": "17.3.0",
     "@metamask/keyring-snap-sdk": "3.0.1",
     "@metamask/snaps-cli": "6.5.1",
     "@metamask/snaps-jest": "8.12.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "pGQ4C4+ClecT6LmyhpZlVdXWL13tJw2wrzO8W4sJwMk=",
+    "shasum": "/qiHe8fTr7u08yYA8QUqbgMsFHsgYr+P4M72sHsPDLQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
@@ -382,6 +382,7 @@ describe('SolanaKeyring', () => {
       expect(emitEventSpy).toHaveBeenCalledWith('notify:accountCreated', {
         accountNameSuggestion: 'My Cool Account Name',
         displayAccountNameSuggestion: false,
+        displayConfirmation: false,
         account,
       });
     });

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 /* eslint-disable @typescript-eslint/prefer-reduce-type-parameter */
+import type { MetaMaskOptions } from '@metamask/keyring-api';
 import {
   KeyringEvent,
   ListAccountAssetsResponseStruct,
@@ -135,12 +136,14 @@ export class SolanaKeyring implements Keyring {
     return account;
   }
 
-  async createAccount(options?: {
-    importedAccount?: boolean;
-    index?: number;
-    [key: string]: Json | undefined;
-    accountNameSuggestion?: string;
-  }): Promise<KeyringAccount> {
+  async createAccount(
+    options?: {
+      importedAccount?: boolean;
+      index?: number;
+      [key: string]: Json | undefined;
+      accountNameSuggestion?: string;
+    } & MetaMaskOptions,
+  ): Promise<KeyringAccount> {
     // eslint-disable-next-line no-restricted-globals
     const id = crypto.randomUUID();
 
@@ -166,6 +169,7 @@ export class SolanaKeyring implements Keyring {
         importedAccount,
         index: _,
         accountNameSuggestion,
+        metamask: metamaskOptions,
         ...remainingOptions
       } = options ?? {};
 
@@ -213,6 +217,16 @@ export class SolanaKeyring implements Keyring {
         accountNameSuggestion:
           accountNameSuggestion ?? `Solana Account ${index + 1}`,
         displayAccountNameSuggestion: !accountNameSuggestion,
+        // Skip account creation confirmation dialogs to make it look like a native
+        // account creation flow.
+        displayConfirmation: false,
+        // Internal options to MetaMask that includes a correlation ID. We need
+        // to also emit this ID to the Snap keyring.
+        ...(metamaskOptions
+          ? {
+              metamask: metamaskOptions,
+            }
+          : {}),
       });
 
       return keyringAccount;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,12 +2571,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/common@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@ethereumjs/common@npm:4.4.0"
+  dependencies:
+    "@ethereumjs/util": ^9.1.0
+  checksum: 6b8cbfcfb5bdde839545c89dce3665706733260e26455d0eb3bcbc3c09e371ae629d51032b95d86f2aeeb15325244a6622171f9005165266fefd923eaa99f1c5
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/rlp@npm:^4.0.1":
   version: 4.0.1
   resolution: "@ethereumjs/rlp@npm:4.0.1"
   bin:
     rlp: bin/rlp
   checksum: 30db19c78faa2b6ff27275ab767646929207bb207f903f09eb3e4c273ce2738b45f3c82169ddacd67468b4f063d8d96035f2bf36f02b6b7e4d928eefe2e3ecbc
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/rlp@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@ethereumjs/rlp@npm:5.0.2"
+  bin:
+    rlp: bin/rlp.cjs
+  checksum: b569061ddb1f4cf56a82f7a677c735ba37f9e94e2bbaf567404beb9e2da7aa1f595e72fc12a17c61f7aec67fd5448443efe542967c685a2fe0ffc435793dcbab
   languageName: node
   linkType: hard
 
@@ -2592,6 +2610,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/tx@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "@ethereumjs/tx@npm:5.4.0"
+  dependencies:
+    "@ethereumjs/common": ^4.4.0
+    "@ethereumjs/rlp": ^5.0.2
+    "@ethereumjs/util": ^9.1.0
+    ethereum-cryptography: ^2.2.1
+  checksum: 72882a977dee4a15b5216ccdee906b6d9488e3ab93cadc1d6639a841e81b91c71d01221c56ac541026d592b8b33345cdc5468e711013e8fa33ac6da18089cf2c
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/util@npm:^8.1.0":
   version: 8.1.0
   resolution: "@ethereumjs/util@npm:8.1.0"
@@ -2600,6 +2630,16 @@ __metadata:
     ethereum-cryptography: "npm:^2.0.0"
     micro-ftch: "npm:^0.3.1"
   checksum: 9ae5dee8f12b0faf81cd83f06a41560e79b0ba96a48262771d897a510ecae605eb6d84f687da001ab8ccffd50f612ae50f988ef76e6312c752897f462f3ac08d
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/util@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@ethereumjs/util@npm:9.1.0"
+  dependencies:
+    "@ethereumjs/rlp": ^5.0.2
+    ethereum-cryptography: ^2.2.1
+  checksum: 594e009c3001ca1ca658b4ded01b38e72f5dd5dd76389efd90cb020de099176a3327685557df268161ac3144333cfe8abaae68cda8ae035d9cc82409d386d79a
   languageName: node
   linkType: hard
 
@@ -4136,15 +4176,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:17.2.1, @metamask/keyring-api@npm:^17.2.1":
-  version: 17.2.1
-  resolution: "@metamask/keyring-api@npm:17.2.1"
+"@metamask/keyring-api@npm:17.3.0, @metamask/keyring-api@npm:^17.3.0":
+  version: 17.3.0
+  resolution: "@metamask/keyring-api@npm:17.3.0"
   dependencies:
-    "@metamask/keyring-utils": ^2.3.1
+    "@metamask/keyring-utils": ^3.0.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^11.1.0
     bech32: ^2.0.0
-  checksum: 0902b468fed087e438a8b728cf729d86ecf40ca21d626cc16c884893580d0ed599d5e05eb0b349b5790d0592968643a51f70c4f9e2110d6535e273213d6c8d81
+  checksum: 3e913743fca5ecf74530752322caa4f840a55175886c0c7b9a9185d8e9fa91cc81b1fb52fa360b85fc4560ca4c5a1202b8eb7d16b7f7a6b2237df1b62317817a
   languageName: node
   linkType: hard
 
@@ -4163,7 +4203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-utils@npm:^2.3.0, @metamask/keyring-utils@npm:^2.3.1":
+"@metamask/keyring-utils@npm:^2.3.0":
   version: 2.3.1
   resolution: "@metamask/keyring-utils@npm:2.3.1"
   dependencies:
@@ -4172,6 +4212,18 @@ __metadata:
     "@metamask/utils": ^11.1.0
     bitcoin-address-validation: ^2.2.3
   checksum: cd27eebbc7277a85a922cd581a2eaf3c82521cf5df62e4de6fea2bbdf9d68461d5e51eab08a0eb26c0bf5873f12ff85b7211f629dc1f8eb2e055225b1e2075a8
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/keyring-utils@npm:3.0.0"
+  dependencies:
+    "@ethereumjs/tx": ^5.4.0
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^11.1.0
+    bitcoin-address-validation: ^2.2.3
+  checksum: 4be628fb04d33a528d8142640251ba763437a6b82b497557098f2ae5e27e83c6e0f2c744b505a0f915130c325ac18a696effd0479253c63b8c48c1cb6aade4a1
   languageName: node
   linkType: hard
 
@@ -4673,7 +4725,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@metamask/auto-changelog": 4.0.0
     "@metamask/key-tree": 9.1.2
-    "@metamask/keyring-api": 17.2.1
+    "@metamask/keyring-api": 17.3.0
     "@metamask/keyring-snap-sdk": 3.0.1
     "@metamask/snaps-cli": 6.5.1
     "@metamask/snaps-jest": 8.12.0
@@ -4711,7 +4763,7 @@ __metadata:
     "@chakra-ui/react": ^3.0.2
     "@emotion/react": ^11.13.3
     "@metamask/eslint-config-browser": ^12.1.0
-    "@metamask/keyring-api": ^17.2.1
+    "@metamask/keyring-api": ^17.3.0
     "@metamask/providers": ^18.1.0
     "@solana-program/compute-budget": ^0.7.0
     "@solana-program/system": ^0.7.0
@@ -14474,7 +14526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereum-cryptography@npm:^2.1.2":
+"ethereum-cryptography@npm:^2.1.2, ethereum-cryptography@npm:^2.2.1":
   version: 2.2.1
   resolution: "ethereum-cryptography@npm:2.2.1"
   dependencies:


### PR DESCRIPTION
We have added a new "internal context" during `keyring_createAccount` that allows use to customize the account creation flow within the Snap keyring.

In order to "correlate" the initial call to a `keyring_createAccount` and its associated `notify:accountCreated` event, a new `metamask` object must be forwarded to the event.