### PR TITLE
fix: transaction skip preflight

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "gm9XuW+qqDA8SQBMVOWwNMH040E+tmFQiBbPzysjDzs=",
+    "shasum": "z7UJxFeBcj3A5oWoutkofwrSKJZHAXlOvVhot7IS+qY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/onTransactionFinalized.ts
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/onTransactionFinalized.ts
@@ -45,7 +45,13 @@ export const onTransactionFinalized: OnCronjobHandler = async ({ request }) => {
     // Identify accounts that are involved in the transaction. We will perform refreshes for these specifically
     const fromAddresses = transaction.from.map((from) => from.address);
     const toAddresses = transaction.to.map((to) => to.address);
-    const toAndFromAddresses = [...fromAddresses, ...toAddresses];
+    const toAndFromAddresses = [
+      // The account that triggered the cronjob
+      account.address,
+      // The accounts that are involved in the transaction
+      ...fromAddresses,
+      ...toAddresses,
+    ];
     const accountsChanged = allAccounts.filter((item) =>
       toAndFromAddresses.includes(item.address),
     );

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -231,6 +231,7 @@ export class WalletService {
 
     await sendTransactionWithoutConfirming(signedTransaction, {
       commitment: 'confirmed',
+      skipPreflight: true,
     });
 
     // Trigger the side effects that need to happen when the transaction is submitted


### PR DESCRIPTION
* Adds `skipPreflight` tot he send transaction letting the transaction go on chain without simulation (same behaviour as Phantom)
* Adds the account address executing the transaction request for check (example: on a transaction that fails, we don't have from or to so the cronjob won't check transactions for any account)