### PR TITLE
fix: add "all" time range to historical prices returned

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "Yd6fC98OLwl48/Hh5iaEuksfqjjPmFpwdO6xeUkrSXc=",
+    "shasum": "ubfEH1rWCHt9c+8Iq2754Qj0wXxexmyaubpKw2dPWWg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/clients/price-api/PriceApiClient.ts
+++ b/packages/snap/src/core/clients/price-api/PriceApiClient.ts
@@ -140,7 +140,7 @@ export class PriceApiClient {
         {},
       );
 
-      // Cache the spot prices for 5 minutes
+      // Store in the cache
       await this.#cache.mset(
         tokenCaip19Ids.map((tokenCaip19Id) => ({
           key: `PriceApiClient:getMultipleSpotPrices:${tokenCaip19Id}:${vsCurrency}`,

--- a/packages/snap/src/core/services/token-prices/TokenPrices.test.ts
+++ b/packages/snap/src/core/services/token-prices/TokenPrices.test.ts
@@ -463,6 +463,7 @@ describe('TokenPricesService', () => {
           P1M: expectedPrices,
           P3M: expectedPrices,
           P1Y: expectedPrices,
+          P1000Y: expectedPrices,
         },
         updateTime: expect.any(Number),
         expirationTime: expect.any(Number),

--- a/packages/snap/src/core/services/token-prices/TokenPrices.ts
+++ b/packages/snap/src/core/services/token-prices/TokenPrices.ts
@@ -251,7 +251,7 @@ export class TokenPricesService {
     const toTicker = parseCaipAssetType(to).assetReference.toLowerCase();
     assert(toTicker, VsCurrencyParamStruct);
 
-    const timePeriodsToFetch = ['1d', '7d', '1m', '3m', '1y'];
+    const timePeriodsToFetch = ['1d', '7d', '1m', '3m', '1y', '1000y'];
 
     // For each time period, call the Price API to fetch the historical prices
     const promises = timePeriodsToFetch.map(async (timePeriod) =>


### PR DESCRIPTION
Add missing time range "All" to the historical prices the snap returns. Price API does not support something like `timePeriod=all`, so we use `1000Y` in the same fashion as in the extension code to fetch EVM prices.

![image](https://github.com/user-attachments/assets/8750d885-1ed3-4811-bd96-98d6d1bc0aad)
