### PR TITLE
chore: expose getMinimumBalanceForRentExemption as an RPC method

### DIFF
--- a/packages/snap/src/core/handlers/onRpcRequest/getMinimumBalanceForRentExemption.tsx
+++ b/packages/snap/src/core/handlers/onRpcRequest/getMinimumBalanceForRentExemption.tsx
@@ -1,0 +1,27 @@
+import { InternalError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { assert } from '@metamask/superstruct';
+
+import {  transactionHelper } from '../../../snapContext';
+import logger from '../../utils/logger';
+import { GetMinimumBalanceForRentExemptionParamsStruct, GetMinimumBalanceForRentExemptionResponseStruct } from '../../validation/structs';
+
+export const getMinimumBalanceForRentExemption: OnRpcRequestHandler = async ({ request }) => {  const { params } = request;
+  assert(params, GetMinimumBalanceForRentExemptionParamsStruct);
+
+  const { scope, accountSize } = params;
+
+  try {
+     const value = await transactionHelper.getMinimumBalanceForRentExemption(
+      scope,
+      accountSize?BigInt(accountSize): undefined,
+    );
+
+  const result = {value: value.toString()}
+    assert(result, GetMinimumBalanceForRentExemptionResponseStruct);
+
+    return result;
+  } catch (error) {
+    logger.error(error);
+    throw new InternalError(error as string) as Error;
+  }
+};

--- a/packages/snap/src/core/handlers/onRpcRequest/index.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/index.ts
@@ -3,8 +3,10 @@ import { type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { renderSend } from '../../../features/send/render';
 import { getFeeForTransaction } from './getFeeForTransaction';
 import { RpcRequestMethod } from './types';
+import { getMinimumBalanceForRentExemption } from './getMinimumBalanceForRentExemption';
 
 export const handlers: Record<RpcRequestMethod, OnRpcRequestHandler> = {
   [RpcRequestMethod.StartSendTransactionFlow]: renderSend,
   [RpcRequestMethod.GetFeeForTransaction]: getFeeForTransaction,
+  [RpcRequestMethod.GetMinimumBalanceForRentExemption]: getMinimumBalanceForRentExemption,
 };

--- a/packages/snap/src/core/handlers/onRpcRequest/types.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/types.ts
@@ -1,4 +1,5 @@
 export enum RpcRequestMethod {
   StartSendTransactionFlow = 'startSendTransactionFlow',
   GetFeeForTransaction = 'getFeeForTransaction',
+  GetMinimumBalanceForRentExemption = 'getMinimumBalanceForRentExemption',
 }

--- a/packages/snap/src/core/validation/structs.ts
+++ b/packages/snap/src/core/validation/structs.ts
@@ -269,6 +269,16 @@ export const GetFeeForTransactionResponseStruct = object({
   value: nullable(PositiveNumberStringStruct),
 });
 
+export const GetMinimumBalanceForRentExemptionParamsStruct = object({
+  scope: enums(Object.values(Network)),
+  accountSize: nullable(PositiveNumberStringStruct),
+});
+
+export const GetMinimumBalanceForRentExemptionResponseStruct = object({
+  value: nullable(PositiveNumberStringStruct),
+});
+
+
 /**
  * Validates if a string is Base58 encoded.
  * Base58 uses alphanumeric characters excluding 0, O, I, and l.

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -27,6 +27,7 @@ const dappPermissions = isDev
       // RPC methods
       RpcRequestMethod.StartSendTransactionFlow,
       RpcRequestMethod.GetFeeForTransaction,
+      RpcRequestMethod.GetMinimumBalanceForRentExemption,
       // Protocol methods
       SolanaProtocolRequestMethod.GetGenesisHash,
       SolanaProtocolRequestMethod.GetLatestBlockhash,
@@ -48,6 +49,7 @@ const metamaskPermissions = new Set([
   // RPC methods
   RpcRequestMethod.StartSendTransactionFlow,
   RpcRequestMethod.GetFeeForTransaction,
+  RpcRequestMethod.GetMinimumBalanceForRentExemption,
   // Protocol methods
   SolanaProtocolRequestMethod.GetGenesisHash,
   SolanaProtocolRequestMethod.GetLatestBlockhash,


### PR DESCRIPTION
This PR exposes the `getMinimumBalanceForRentExemption` method used by the Send flow so that the Swap and Bridge experiences can reuse it. The result will be used to set the maximum SOL that can be bridged or swapped by an account.

Draft extension POC: https://github.com/MetaMask/metamask-extension/pull/32947. I plan to move the integration to the @metamask/bridge-controller so that mobile can reuse the logic