### PR TITLE
feat: disable continue button on scan error

### DIFF
--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -170,7 +170,7 @@
       "message": "This transaction was reverted during simulation."
     },
     "confirmation.simulationErrorSubtitle": {
-      "message": "Reason: {reason}"
+      "message": "{reason}"
     },
     "confirmation.validationErrorTitle": {
       "message": "This is a deceptive request"
@@ -239,10 +239,10 @@
       "message": "Resources"
     },
     "errors.accountAlreadyInUse": {
-      "message": "An account with the same address already exists"
+      "message": "An account with the same address already exists."
     },
     "errors.insufficientSol": {
-      "message": "Account does not have enough SOL to perform the operation"
+      "message": "Account does not have enough SOL to perform the operation."
     },
     "errors.slippageToleranceExceeded": {
       "message": "The transaction was reverted because the slippage tolerance was exceeded."

--- a/packages/snap/messages.json
+++ b/packages/snap/messages.json
@@ -55,7 +55,7 @@
   "confirmation.fee": "Network fee",
   "confirmation.feeError": "Unable to estimate fee",
   "confirmation.simulationErrorTitle": "This transaction was reverted during simulation.",
-  "confirmation.simulationErrorSubtitle": "Reason: {reason}",
+  "confirmation.simulationErrorSubtitle": "{reason}",
   "confirmation.validationErrorTitle": "This is a deceptive request",
   "confirmation.validationErrorSubtitle": "If you approve this request, a third party known for scams will take all your assets.",
   "confirmation.validationErrorLearnMore": "Learn more",
@@ -78,7 +78,7 @@
   "confirmation.signIn.notBefore": "Not before",
   "confirmation.signIn.requestId": "Request ID",
   "confirmation.signIn.resources": "Resources",
-  "errors.accountAlreadyInUse": "An account with the same address already exists",
-  "errors.insufficientSol": "Account does not have enough SOL to perform the operation",
+  "errors.accountAlreadyInUse": "An account with the same address already exists.",
+  "errors.insufficientSol": "Account does not have enough SOL to perform the operation.",
   "errors.slippageToleranceExceeded": "The transaction was reverted because the slippage tolerance was exceeded."
 }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "03FCr0dmyKPvqmCuEDRmjvGUG0wKyKRq3T+CJiSoPUQ=",
+    "shasum": "EdiJ47RS3AYUiThQu6hyTBLrzwIBvqSOTvVd+onfLNI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/features/confirmation/components/TransactionAlert/TransactionAlert.tsx
+++ b/packages/snap/src/features/confirmation/components/TransactionAlert/TransactionAlert.tsx
@@ -13,8 +13,8 @@ import type {
   TransactionScanValidation,
 } from '../../../../core/services/transaction-scan/types';
 import type { FetchStatus, Preferences } from '../../../../core/types/snap';
-import { getErrorMessage } from '../../../../core/utils/errorMessages';
 import { i18n } from '../../../../core/utils/i18n';
+import { getErrorMessage } from './getErrorMessage';
 
 type TransactionAlertProps = {
   preferences: Preferences;
@@ -68,13 +68,11 @@ export const TransactionAlert: SnapComponent<TransactionAlertProps> = ({
         title={translate('confirmation.simulationErrorTitle')}
         severity="warning"
       >
-        {error?.code ? (
-          <Text>
-            {translate('confirmation.simulationErrorSubtitle', {
-              reason: getErrorMessage(error.code, preferences),
-            })}
-          </Text>
-        ) : null}
+        <Text>
+          {translate('confirmation.simulationErrorSubtitle', {
+            reason: getErrorMessage(error, preferences),
+          })}
+        </Text>
       </Banner>
     );
   }

--- a/packages/snap/src/features/confirmation/components/TransactionAlert/getErrorMessage.ts
+++ b/packages/snap/src/features/confirmation/components/TransactionAlert/getErrorMessage.ts
@@ -1,10 +1,11 @@
-import type { Preferences } from '../types/snap';
-import { i18n } from './i18n';
+import type { TransactionScanError } from '../../../../core/services/transaction-scan/types';
+import type { Preferences } from '../../../../core/types/snap';
+import { i18n } from '../../../../core/utils/i18n';
 
 /**
  * Maps error codes to user-friendly messages
  */
-export const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES: Record<string, string> = {
   AccountAlreadyInUse: 'errors.accountAlreadyInUse',
   ResultWithNegativeLamports: 'errors.insufficientSol',
   SlippageToleranceExceeded: 'errors.slippageToleranceExceeded', // Jupiter
@@ -12,20 +13,26 @@ export const ERROR_MESSAGES: Record<string, string> = {
 };
 
 /**
- * Gets a user-friendly message for an error code.
- * @param errorCode - The error code to get a message for.
+ * Gets a user-friendly message from a transaction scan error.
+ * @param error - The error of the transaction scan.
  * @param preferences - The user preferences containing locale information.
  * @returns A user-friendly error message, or the original error code if no mapping exists.
  */
 export function getErrorMessage(
-  errorCode: string,
+  error: TransactionScanError,
   preferences: Preferences,
 ): string {
   const translate = i18n(preferences.locale);
-  const translationKey = ERROR_MESSAGES[errorCode];
+  const { code } = error;
+
+  if (!code) {
+    return 'errors.unknownError';
+  }
+
+  const translationKey = ERROR_MESSAGES[code];
 
   if (!translationKey) {
-    return errorCode;
+    return 'errors.unknownError';
   }
 
   return translate(translationKey as keyof typeof translate);

--- a/packages/snap/src/features/confirmation/components/TransactionAlert/index.ts
+++ b/packages/snap/src/features/confirmation/components/TransactionAlert/index.ts
@@ -1,0 +1,1 @@
+export { TransactionAlert } from './TransactionAlert';

--- a/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/ConfirmTransactionRequest.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/ConfirmTransactionRequest.tsx
@@ -10,7 +10,7 @@ import { Networks } from '../../../../core/constants/solana';
 import { i18n } from '../../../../core/utils/i18n';
 import { Advanced } from '../../components/Advanced/Advanced';
 import { EstimatedChanges } from '../../components/EstimatedChanges/EstimatedChanges';
-import { TransactionAlert } from '../../components/TransactionAlert/TransactionAlert';
+import { TransactionAlert } from '../../components/TransactionAlert';
 import { TransactionDetails } from '../../components/TransactionDetails/TransactionDetails';
 import { ConfirmSignAndSendTransactionFormNames } from './events';
 import { type ConfirmTransactionRequestContext } from './types';
@@ -25,7 +25,9 @@ export const ConfirmTransactionRequest = ({
   const feeInSol = context.feeEstimatedInSol;
   const { nativeToken } = Networks[context.scope];
   const nativePrice = context.tokenPrices[nativeToken.caip19Id]?.price ?? null;
-  const scanIsFetching = context.scanFetchStatus === 'fetching';
+
+  const shouldDisableConfirmButton =
+    context.scanFetchStatus === 'fetching' || context.scan?.status === 'ERROR';
 
   return (
     <Container>
@@ -73,7 +75,7 @@ export const ConfirmTransactionRequest = ({
         </Button>
         <Button
           name={ConfirmSignAndSendTransactionFormNames.Confirm}
-          disabled={scanIsFetching}
+          disabled={shouldDisableConfirmButton}
         >
           {translate('confirmation.confirmButton')}
         </Button>


### PR DESCRIPTION
This PR disables the "Confirm" button in confirmation screen whenever the transaction simulation fails.

## When trying to swap too much SOL ( no SOL left for fees)
![image](https://github.com/user-attachments/assets/f272054d-c548-4c5b-a598-cd2a3eb2dc34)

## Happy case, when trying swap an valid amount
![image](https://github.com/user-attachments/assets/57a9faa4-933a-4711-98a3-cdcc36c9265f)
