### PR TITLE
feat: validate same origin domain for signin

### DIFF
--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -250,6 +250,9 @@
     "confirmation.signIn.resources": {
       "message": "Resources"
     },
+    "confirmation.signIn.badDomain": {
+      "message": "This site is asking you to sign in using the wrong domain."
+    },
     "transactionScan.errors.accountAlreadyInUse": {
       "message": "An account with the same address already exists."
     },

--- a/packages/snap/messages.json
+++ b/packages/snap/messages.json
@@ -82,6 +82,7 @@
   "confirmation.signIn.notBefore": "Not before",
   "confirmation.signIn.requestId": "Request ID",
   "confirmation.signIn.resources": "Resources",
+  "confirmation.signIn.badDomain": "This site is asking you to sign in using the wrong domain.",
   "transactionScan.errors.accountAlreadyInUse": "An account with the same address already exists.",
   "transactionScan.errors.insufficientSol": "Account does not have enough SOL to perform the operation.",
   "transactionScan.errors.slippageToleranceExceeded": "The transaction was reverted because the slippage tolerance was exceeded.",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "Lu8ZjslFGAsh8xSiKiOPdzbyxIG8Hrp7h6ijDea9oVo=",
+    "shasum": "CGJCQcU/gwXmG51oX44op5db6mwEBogWvzfbBJZ26bs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
@@ -74,6 +74,7 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
   const signInAddressCaip10 = address ? addressToCaip10(scope, address) : null;
 
   const isBadAccount = signInAddressCaip10 !== accountAddressCaip10;
+  const isBadDomain = domain !== originHostname;
 
   return (
     <Container>
@@ -104,7 +105,15 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
               <Text>{originHostname}</Text>
             </Row>
           ) : null}
-          <Row label={translate('confirmation.signIn.domain')}>
+          <Row
+            variant={isBadDomain ? 'critical' : 'default'}
+            label={translate('confirmation.signIn.domain')}
+            tooltip={
+              isBadDomain
+                ? translate('confirmation.signIn.badDomain')
+                : undefined
+            }
+          >
             <Text>
               {domain ?? translate('confirmation.signIn.unknownDomain')}
             </Text>
@@ -212,7 +221,10 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
         <Button name={ConfirmSignInFormNames.Cancel}>
           {translate('confirmation.cancelButton')}
         </Button>
-        <Button name={ConfirmSignInFormNames.Confirm}>
+        <Button
+          name={ConfirmSignInFormNames.Confirm}
+          variant={isBadDomain ? 'destructive' : 'primary'}
+        >
           {translate('confirmation.confirmButton')}
         </Button>
       </Footer>


### PR DESCRIPTION
If the `domain` is different than `origin` an alert shows tot he user on the confirmation

<img width="395" alt="Screenshot 2025-06-27 at 14 47 32" src="https://github.com/user-attachments/assets/4fbcfc3c-35a7-4f08-9043-040bdba65545" />
<img width="400" alt="Screenshot 2025-06-27 at 14 46 44" src="https://github.com/user-attachments/assets/2cbe70a8-c90f-49ec-904d-8952442f0038" />
