### PR TITLE
Small improvements

### DIFF
--- a/packages/site/src/components/Handlers/WebSockets.tsx
+++ b/packages/site/src/components/Handlers/WebSockets.tsx
@@ -23,6 +23,18 @@ export const WebSockets = () => {
     });
   };
 
+  const closeAllConnections = async () => {
+    showToasterForResponse(
+      { result: 'ok' },
+      {
+        title: 'Closed all WebSocket connections',
+      },
+    );
+    await invokeSnap({
+      method: TestDappRpcRequestMethod.TestCloseAllConnections,
+    });
+  };
+
   const subscribeToAccount = async () => {
     await invokeSnap({
       method: TestDappRpcRequestMethod.TestSubscribeToAccount,
@@ -51,6 +63,13 @@ export const WebSockets = () => {
             marginRight="1"
           >
             Setup All Connections
+          </Button>
+          <Button
+            variant="outline"
+            onClick={closeAllConnections}
+            marginRight="1"
+          >
+            Close All Connections
           </Button>
         </Flex>
         <Flex>

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "Wz3gtyw2ZvaXCBJWXOm0RRlPbhJHKXS21e0/0OOdB6w=",
+    "shasum": "tWTe+7InQX32jj/Bn9zUyxFhyJGUb2XP1kW4pm0RWls=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "g/jfpUCvmwu6piUwA21tuyxrmaZZnZl3JdLeVJysYFM=",
+    "shasum": "Wz3gtyw2ZvaXCBJWXOm0RRlPbhJHKXS21e0/0OOdB6w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,7 +19,8 @@
     "locales": ["locales/en.json"]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {}
+    "https://portfolio.metamask.io": {},
+    "http://localhost:3000": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -27,7 +28,10 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": ["https://portfolio.metamask.io"]
+      "allowedOrigins": [
+        "https://portfolio.metamask.io",
+        "http://localhost:3000"
+      ]
     },
     "snap_getBip32Entropy": [
       {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "tWTe+7InQX32jj/Bn9zUyxFhyJGUb2XP1kW4pm0RWls=",
+    "shasum": "EBrVuE+uXKdUKPSGja1momxWXqItfVGppjHtfMaDo+I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,8 +19,7 @@
     "locales": ["locales/en.json"]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {},
-    "http://localhost:3000": {}
+    "https://portfolio.metamask.io": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -28,10 +27,7 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": [
-        "https://portfolio.metamask.io",
-        "http://localhost:3000"
-      ]
+      "allowedOrigins": ["https://portfolio.metamask.io"]
     },
     "snap_getBip32Entropy": [
       {

--- a/packages/snap/src/core/handlers/onRpcRequest/index.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/index.ts
@@ -18,4 +18,8 @@ export const handlers: Record<RpcRequestMethod, OnRpcRequestHandler> = {
     await eventEmitter.emitSync('onTestSubscribeToAccount');
     return null;
   },
+  [TestDappRpcRequestMethod.TestCloseAllConnections as any]: async () => {
+    await eventEmitter.emitSync('onTestCloseAllConnections');
+    return null;
+  },
 };

--- a/packages/snap/src/core/handlers/onRpcRequest/types.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/types.ts
@@ -10,4 +10,5 @@ export enum RpcRequestMethod {
 export enum TestDappRpcRequestMethod {
   TestSetupAllConnections = 'testSetupAllConnections',
   TestSubscribeToAccount = 'testSubscribeToAccount',
+  TestCloseAllConnections = 'testCloseAllConnections',
 }

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionRepository.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionRepository.ts
@@ -1,4 +1,6 @@
 import type { WebSocketConnection } from '../../../entities';
+import type { Network } from '../../constants/solana';
+import type { ConfigProvider } from '../config';
 
 /**
  * Repository that is treating the Snap's WebSocket storage as a persistent data store, where:
@@ -9,12 +11,33 @@ import type { WebSocketConnection } from '../../../entities';
  * It also tracks bidirectional mappings between the connection ID and the URL to perform fast lookups.
  */
 export class WebSocketConnectionRepository {
-  async getAll(): Promise<WebSocketConnection[]> {
-    return snap.request({
-      method: 'snap_getWebSockets',
-    });
+  readonly #configProvider: ConfigProvider;
+
+  constructor(configProvider: ConfigProvider) {
+    this.#configProvider = configProvider;
   }
 
+  /**
+   * Gets all connections.
+   * @returns All connections.
+   */
+  async getAll(): Promise<WebSocketConnection[]> {
+    const snapConnections = await snap.request({
+      method: 'snap_getWebSockets',
+    });
+
+    // Enhance the connections with the network
+    return snapConnections.map((connection) => ({
+      ...connection,
+      network: this.#findNetworkByWebSocketUrl(connection.url),
+    }));
+  }
+
+  /**
+   * Gets the connection for the specified ID.
+   * @param id - The ID of the connection to get.
+   * @returns The connection, or null if no connection exists for the ID.
+   */
   async getById(id: string): Promise<WebSocketConnection | null> {
     const existingConnections = await this.getAll();
     return (
@@ -22,22 +45,31 @@ export class WebSocketConnectionRepository {
     );
   }
 
-  async findByUrl(url: string): Promise<WebSocketConnection | null> {
+  /**
+   * Finds the connection for the specified network.
+   * @param network - The network to find the connection for.
+   * @returns The connection, or null if no connection exists for the network.
+   */
+  async findByNetwork(network: Network): Promise<WebSocketConnection | null> {
     const existingConnections = await this.getAll();
-
     return (
-      existingConnections.find((connection) => connection.url === url) ?? null
+      existingConnections.find(
+        (connection) => connection.network === network,
+      ) ?? null
     );
   }
 
   /**
    * Creates a new connection to the specified URL.
-   * @param url - The URL of the connection.
-   * @param protocols - The protocols of the connection.
+   * @param connection - The connection to create, without the `id` field.
    * @returns The connection ID.
    */
-  async save(url: string, protocols?: string[]) {
-    const connectionId = await snap.request({
+  async save(
+    connection: Omit<WebSocketConnection, 'id'>,
+  ): Promise<WebSocketConnection> {
+    const { url, protocols } = connection;
+
+    const id = await snap.request({
       method: 'snap_openWebSocket',
       params: {
         url,
@@ -45,7 +77,10 @@ export class WebSocketConnectionRepository {
       },
     });
 
-    return connectionId;
+    return {
+      ...connection,
+      id,
+    };
   }
 
   /**
@@ -57,5 +92,23 @@ export class WebSocketConnectionRepository {
       method: 'snap_closeWebSocket',
       params: { id },
     });
+  }
+
+  /**
+   * Gets the network for the specified connection ID.
+   * @param webSocketUrl - The WebSocket URL to get the network for.
+   * @returns The network.
+   */
+  #findNetworkByWebSocketUrl(webSocketUrl: string): Network {
+    const network = this.#configProvider.getNetworkBy(
+      'webSocketUrl',
+      webSocketUrl,
+    );
+
+    if (!network) {
+      throw new Error(`No network found for WebSocket URL: ${webSocketUrl}`);
+    }
+
+    return network.caip2Id;
   }
 }

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -201,7 +201,7 @@ describe('WebSocketConnectionService', () => {
       // Now, calling setupAllConnections will open the Mainnet connection again
       await service.setupAllConnections();
 
-      // The connection has recovered, but the recovery callback should not have been called
+      // The connection has recovered, but the recovery callback should not have been called because it was cleared
       expect(recoveryCallback).not.toHaveBeenCalled();
     });
 

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -13,10 +13,12 @@ const mockConnectionId = 'mock-connection-id';
 const createMockWebSocketConnection = (
   id = mockConnectionId,
   url = mockWebSocketUrl,
+  network = Network.Mainnet,
 ): WebSocketConnection => ({
   id,
   url,
   protocols: [],
+  network,
 });
 
 describe('WebSocketConnectionService', () => {
@@ -50,11 +52,9 @@ describe('WebSocketConnectionService', () => {
     mockWebSocketConnectionRepository = {
       getAll: jest.fn(),
       getById: jest.fn(),
-      findByUrl: jest.fn(),
+      findByNetwork: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
-      getIdByUrl: jest.fn(),
-      getUrlById: jest.fn(),
     } as unknown as WebSocketConnectionRepository;
 
     mockConfigProvider = {
@@ -97,14 +97,16 @@ describe('WebSocketConnectionService', () => {
 
       jest
         .spyOn(mockWebSocketConnectionRepository, 'save')
-        .mockResolvedValueOnce(mockConnectionId);
+        .mockResolvedValueOnce(mockConnectionMainnet);
 
       await service.setupAllConnections();
 
       expect(mockWebSocketConnectionRepository.save).toHaveBeenCalledTimes(1);
-      expect(mockWebSocketConnectionRepository.save).toHaveBeenCalledWith(
-        'wss://some-mock-url2.com/ws/v3/some-id',
-      );
+      expect(mockWebSocketConnectionRepository.save).toHaveBeenCalledWith({
+        network: Network.Devnet,
+        url: 'wss://some-mock-url2.com/ws/v3/some-id',
+        protocols: [],
+      });
     });
 
     it('does nothing for active networks that are already open', async () => {
@@ -135,7 +137,7 @@ describe('WebSocketConnectionService', () => {
         .mockResolvedValueOnce([openConnection]);
 
       jest
-        .spyOn(mockWebSocketConnectionRepository, 'findByUrl')
+        .spyOn(mockWebSocketConnectionRepository, 'findByNetwork')
         .mockResolvedValueOnce(openConnection);
 
       await service.setupAllConnections();
@@ -215,10 +217,12 @@ describe('WebSocketConnectionService', () => {
       });
 
       it('retries until it succeeds, when attempts < 5', async () => {
+        const mockConnection = createMockWebSocketConnection();
+
         jest
           .spyOn(mockWebSocketConnectionRepository, 'save')
           .mockRejectedValueOnce(new Error('Connection failed')) // 1st call is the fail attempt
-          .mockResolvedValueOnce(mockConnectionId); // 2nd call is the success attempt
+          .mockResolvedValueOnce(mockConnection); // 2nd call is the success attempt
 
         await service.setupAllConnections();
 
@@ -247,7 +251,7 @@ describe('WebSocketConnectionService', () => {
           .mockResolvedValue(mockConnection);
 
         jest
-          .spyOn(mockWebSocketConnectionRepository, 'findByUrl')
+          .spyOn(mockWebSocketConnectionRepository, 'findByNetwork')
           .mockResolvedValueOnce(mockConnection);
       });
 
@@ -298,7 +302,7 @@ describe('WebSocketConnectionService', () => {
     it('returns the connection ID for the network', async () => {
       const mockConnection = createMockWebSocketConnection();
       jest
-        .spyOn(mockWebSocketConnectionRepository, 'findByUrl')
+        .spyOn(mockWebSocketConnectionRepository, 'findByNetwork')
         .mockResolvedValueOnce(mockConnection);
 
       const connectionId = await service.getConnectionIdByNetwork(

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -159,7 +159,7 @@ describe('WebSocketConnectionService', () => {
       expect(mockWebSocketConnectionRepository.delete).not.toHaveBeenCalled();
     });
 
-    it('clears the connection recovery callbacks for the closed networks', async () => {
+    it('clears associated recovery callbacks when closing a connection', async () => {
       // Initially, we have a connection for Mainnet
       const mockConnection = createMockWebSocketConnection();
       jest

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -1,11 +1,11 @@
 import type { WebSocketEvent } from '@metamask/snaps-sdk';
 import { difference } from 'lodash';
 
+import type { WebSocketConnection } from '../../../entities';
 import type { EventEmitter } from '../../../infrastructure';
 import { Network } from '../../constants/solana';
 import type { ILogger } from '../../utils/logger';
 import type { ConfigProvider } from '../config';
-import type { NetworkConfig } from '../config/ConfigProvider';
 import type { WebSocketConnectionRepository } from './WebSocketConnectionRepository';
 
 /**
@@ -58,7 +58,6 @@ export class WebSocketConnectionService {
 
     eventEmitter.on('onWebSocketEvent', this.#handleWebSocketEvent.bind(this));
 
-    // Temporary bind to enable manual testing from the test dapp
     // Temporary binds to enable manual testing from the test dapp
     eventEmitter.on(
       'onTestSetupAllConnections',
@@ -85,9 +84,7 @@ export class WebSocketConnectionService {
     const connections = await this.#connectionRepository.getAll();
 
     const isConnectionOpen = (network: Network) =>
-      connections.some(
-        (connection) => connection.url === this.#getWebSocketUrl(network),
-      );
+      connections.some((connection) => connection.network === network);
 
     // Open the connections for the active networks that are not already open
     const openingPromises = activeNetworks
@@ -105,27 +102,28 @@ export class WebSocketConnectionService {
   /**
    * Opens a connection for the specified network.
    * @param network - The network to open a connection for.
-   * @returns A promise that resolves to the connection ID.
+   * @returns A promise that resolves to the connection.
    */
-  async #openConnection(network: Network): Promise<string> {
+  async #openConnection(network: Network): Promise<WebSocketConnection> {
     this.#logger.info(
       this.#loggerPrefix,
       `Opening connection for network ${network}`,
     );
 
     const networkConfig = this.#configProvider.getNetworkBy('caip2Id', network);
-
     const { webSocketUrl } = networkConfig;
-    if (!webSocketUrl) {
-      throw new Error(`No WebSocket URL found for network ${network}`);
-    }
 
-    // Check if the connection already exists
+    // Check if a connection already exists for this network
     const existingConnection =
-      await this.#connectionRepository.findByUrl(webSocketUrl);
+      await this.#connectionRepository.findByNetwork(network);
 
     if (existingConnection) {
-      return existingConnection.id;
+      this.#logger.info(
+        this.#loggerPrefix,
+        `Connection for network ${network} already exists`,
+        existingConnection,
+      );
+      return existingConnection;
     }
 
     let attempts = 0;
@@ -137,10 +135,13 @@ export class WebSocketConnectionService {
           `Opening connection for network ${network} to ${webSocketUrl} (attempt ${attempts + 1}/${this.#maxReconnectAttempts})`,
         );
 
-        const connectionId =
-          await this.#connectionRepository.save(webSocketUrl);
+        const connection = await this.#connectionRepository.save({
+          network,
+          url: webSocketUrl,
+          protocols: [],
+        });
 
-        return connectionId;
+        return connection;
       } catch (error) {
         attempts += 1;
 
@@ -171,6 +172,7 @@ export class WebSocketConnectionService {
 
   /**
    * Closes the connection for the specified network.
+   * This is an intentional close, not a disconnection, so it also removes the connection recovery callbacks for this network.
    * @param network - The network to close the connection for.
    */
   async #closeConnection(network: Network): Promise<void> {
@@ -179,13 +181,12 @@ export class WebSocketConnectionService {
       `Closing connection for network ${network}`,
     );
 
-    const webSocketUrl = this.#getWebSocketUrl(network);
     // Clean up the connection recovery callbacks for this network
     this.#connectionRecoveryCallbacks.delete(network);
 
     // Early return if the connection does not exist
     const existingConnection =
-      await this.#connectionRepository.findByUrl(webSocketUrl);
+      await this.#connectionRepository.findByNetwork(network);
 
     if (!existingConnection) {
       this.#logger.warn(
@@ -202,7 +203,7 @@ export class WebSocketConnectionService {
 
       this.#logger.info(
         this.#loggerPrefix,
-        `Closed connection ${connectionId}`,
+        ` ❌ Closed connection ${connectionId}`,
       );
     } catch (error) {
       this.#logger.error(
@@ -234,8 +235,7 @@ export class WebSocketConnectionService {
    * @returns The connection ID, or null if no connection exists for the network.
    */
   async getConnectionIdByNetwork(network: Network): Promise<string | null> {
-    const wsUrl = this.#getWebSocketUrl(network);
-    const connection = await this.#connectionRepository.findByUrl(wsUrl);
+    const connection = await this.#connectionRepository.findByNetwork(network);
 
     return connection?.id ?? null;
   }
@@ -258,16 +258,7 @@ export class WebSocketConnectionService {
       return;
     }
 
-    const network = this.#findNetworkByWebSocketUrl(connection.url)?.caip2Id;
-
-    if (!network) {
-      this.#logger.warn(
-        this.#loggerPrefix,
-        `No network found matching the URL of the connection`,
-        connection,
-      );
-      return;
-    }
+    const { network } = connection;
 
     this.#logger.info(
       this.#loggerPrefix,
@@ -321,29 +312,12 @@ export class WebSocketConnectionService {
   }
 
   /**
-   * Converts an HTTP RPC URL to a WebSocket URL.
-   * @param network - The network to get the WebSocket URL for.
-   * @returns The WebSocket URL.
    * Closes connections for all networks.
    * This is used to test the connection recovery mechanism.
    */
-  #getWebSocketUrl(network: Network): string {
-    const { webSocketUrl } = this.#configProvider.getNetworkBy(
-      'caip2Id',
-      network,
-    );
-    return webSocketUrl;
-  }
   async #closeAllConnections(): Promise<void> {
     this.#logger.info(this.#loggerPrefix, `Closing all connections`);
 
-  /**
-   * Gets the network for the specified connection ID.
-   * @param webSocketUrl - The WebSocket URL to get the network for.
-   * @returns The network, or null if no network is associated with the connection ID.
-   */
-  #findNetworkByWebSocketUrl(webSocketUrl: string): NetworkConfig | null {
-    return this.#configProvider.getNetworkBy('webSocketUrl', webSocketUrl);
     const allNetworks = Object.values(Network);
 
     const closePromises = allNetworks.map(async (network) => {

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -180,6 +180,8 @@ export class WebSocketConnectionService {
     );
 
     const webSocketUrl = this.#getWebSocketUrl(network);
+    // Clean up the connection recovery callbacks for this network
+    this.#connectionRecoveryCallbacks.delete(network);
 
     // Early return if the connection does not exist
     const existingConnection =

--- a/packages/snap/src/entities/subscriptions.ts
+++ b/packages/snap/src/entities/subscriptions.ts
@@ -55,7 +55,9 @@ export type SubscriptionCallbacks = {
   onConnectionRecovery?: () => Promise<void>;
 };
 
-export type WebSocketConnection = GetWebSocketsResult[number];
+export type WebSocketConnection = GetWebSocketsResult[number] & {
+  readonly network: Network;
+};
 
 /**
  * Once the Subscriber acknowledges the subscription request,

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -39,6 +39,7 @@ const dappPermissions = isDev
       // Methods specific to the test dapp
       TestDappRpcRequestMethod.TestSetupAllConnections,
       TestDappRpcRequestMethod.TestSubscribeToAccount,
+      TestDappRpcRequestMethod.TestCloseAllConnections,
     ])
   : new Set([]);
 

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -118,7 +118,9 @@ const transactionScanService = new TransactionScanService(
 
 const confirmationHandler = new ConfirmationHandler();
 
-const webSocketConnectionRepository = new WebSocketConnectionRepository();
+const webSocketConnectionRepository = new WebSocketConnectionRepository(
+  configProvider,
+);
 
 const webSocketConnectionService = new WebSocketConnectionService(
   webSocketConnectionRepository,


### PR DESCRIPTION
- Clears associated recovery callbacks when closing a connection (see [this convo](https://github.com/MetaMask/snap-solana-wallet/pull/431#discussion_r2177128883))
- Simplify some code by embedding the network field on the `WebSocketConnection` entity
- Can now manually close connections from the test dapp:
![image](https://github.com/user-attachments/assets/9c90d100-03a3-49cf-bdfb-127be4bc3e77)
