### PR TITLE
feat: unsubscribe from delete account

### DIFF
--- a/packages/site/src/context/network.tsx
+++ b/packages/site/src/context/network.tsx
@@ -20,7 +20,7 @@ export const NetworkProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [network, setNetwork] = useState<Network>(Network.Devnet);
+  const [network, setNetwork] = useState<Network>(Network.Mainnet);
 
   return (
     <NetworkContext.Provider value={{ network, setNetwork }}>

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.36.0",
+  "version": "1.35.2",
   "description": "Manage Solana using MetaMask",
   "proposedName": "Solana",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "KzlXLitVlQ2bEGM5dceouZ/4XlpQgKT+sEUFrDFDx+c=",
+    "shasum": "jxeQeqsoAhF9VQP6e+xrpCWsu08gYq4CXk9iqNlzDLI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -16,12 +16,11 @@
         "registry": "https://registry.npmjs.org/"
       }
     },
-    "locales": [
-      "locales/en.json"
-    ]
+    "locales": ["locales/en.json"]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {}
+    "https://portfolio.metamask.io": {},
+    "http://localhost:3000": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -30,16 +29,13 @@
     },
     "endowment:keyring": {
       "allowedOrigins": [
-        "https://portfolio.metamask.io"
+        "https://portfolio.metamask.io",
+        "http://localhost:3000"
       ]
     },
     "snap_getBip32Entropy": [
       {
-        "path": [
-          "m",
-          "44'",
-          "501'"
-        ],
+        "path": ["m", "44'", "501'"],
         "curve": "ed25519"
       }
     ],

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.35.2",
+  "version": "1.36.0",
   "description": "Manage Solana using MetaMask",
   "proposedName": "Solana",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "a4jxKwHdnGWon/F+VC2iHmp7OguXs43rrsr6idpgy0o=",
+    "shasum": "ft8dsbuORrOdO/YGvPIbOjO76RI7HAuiwCLzkobfyDo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "ft8dsbuORrOdO/YGvPIbOjO76RI7HAuiwCLzkobfyDo=",
+    "shasum": "1b4tpn3m4P1m/yR1EJPNcNtOYCu7ws/svLqbFjGyAJU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "jxeQeqsoAhF9VQP6e+xrpCWsu08gYq4CXk9iqNlzDLI=",
+    "shasum": "a4jxKwHdnGWon/F+VC2iHmp7OguXs43rrsr6idpgy0o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/constants/solana.ts
+++ b/packages/snap/src/core/constants/solana.ts
@@ -27,7 +27,7 @@ export enum KnownCaip19Id {
   SolLocalnet = `${Network.Localnet}/slip44:501`,
   UsdcMainnet = `${Network.Mainnet}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
   UsdcDevnet = `${Network.Devnet}/token:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`,
-  UsdcLocalnet = `${Network.Localnet}/token:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`,
+  UsdcLocalnet = `${Network.Localnet}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
   EurcMainnet = `${Network.Mainnet}/token:HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr`,
   EurcDevnet = `${Network.Devnet}/token:HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr`,
   EurcLocalnet = `${Network.Localnet}/token:HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr`,

--- a/packages/snap/src/core/constants/solana.ts
+++ b/packages/snap/src/core/constants/solana.ts
@@ -1,5 +1,4 @@
 import { define, pattern, string } from '@metamask/superstruct';
-import { address } from '@solana/kit';
 
 /* eslint-disable no-restricted-globals */
 export const SOL_SYMBOL = 'SOL';
@@ -152,10 +151,6 @@ export const TokenMetadata = {
     decimals: 6,
   },
 } as const;
-
-export const TOKEN_2022_PROGRAM_ADDRESS = address(
-  'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
-);
 
 export const Networks = {
   [Network.Mainnet]: {

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
@@ -88,6 +88,7 @@ describe('SolanaKeyring', () => {
       listAccountAssets: jest.fn(),
       getAccountBalances: jest.fn(),
       monitorAccountAssets: jest.fn(),
+      stopMonitorAccountAssets: jest.fn(),
     } as unknown as AssetsService;
 
     mockWalletService = {
@@ -557,6 +558,14 @@ describe('SolanaKeyring', () => {
         MOCK_SOLANA_KEYRING_ACCOUNT_1.id,
       );
       expect(accountAfterDeletion).toBeUndefined();
+    });
+
+    it('stops monitoring the account assets', async () => {
+      await keyring.deleteAccount(MOCK_SOLANA_KEYRING_ACCOUNT_1.id);
+
+      expect(mockAssetsService.stopMonitorAccountAssets).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_1,
+      );
     });
 
     it('throws an error if account provided is not a uuid', async () => {

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
@@ -323,9 +323,13 @@ export class SolanaKeyring implements Keyring {
     try {
       validateRequest({ accountId }, DeleteAccountStruct);
 
+      const account = await this.getAccountOrThrow(accountId);
+
       await this.#deleteAccountFromState(accountId);
 
       await this.emitEvent(KeyringEvent.AccountDeleted, { id: accountId });
+
+      await this.#assetsService.stopMonitorAccountAssets(account);
     } catch (error: any) {
       this.#logger.error({ error }, 'Error deleting account');
       throw error;

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -887,7 +887,10 @@ export class AssetsService {
 
     // Stop monitoring token assets across all active networks
     const tokenAssetsPromises = tokenAccounts.map(async (tokenAccount) =>
-      this.#accountMonitor.stopMonitoring(address, tokenAccount.scope),
+      this.#accountMonitor.stopMonitoring(
+        tokenAccount.pubkey,
+        tokenAccount.scope,
+      ),
     );
 
     await Promise.allSettled([...nativeAssetsPromises, ...tokenAssetsPromises]);

--- a/packages/snap/src/core/services/mocks/mockSolanaRpcResponses.ts
+++ b/packages/snap/src/core/services/mocks/mockSolanaRpcResponses.ts
@@ -128,7 +128,7 @@ export const MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE = {
           data: {
             parsed: {
               info: {
-                mint: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU', // USDC
+                mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
                 owner: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
                 isNative: false,
                 tokenAmount: {
@@ -139,6 +139,7 @@ export const MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE = {
             },
           },
         },
+        pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
       },
       {
         account: {
@@ -156,6 +157,7 @@ export const MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE = {
             },
           },
         },
+        pubkey: 'DJGpJufSnVDriDczovhcQRyxamKtt87PHQ7TJEcVB6ta',
       },
     ],
   },

--- a/packages/snap/src/core/services/subscriptions/AccountMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/AccountMonitor.test.ts
@@ -164,13 +164,19 @@ describe('AccountMonitor', () => {
 
   describe('stopMonitoring', () => {
     it('unsubscribes from the subscription', async () => {
-      const subscriptionId = await accountMonitor.monitor(params);
+      await accountMonitor.monitor(params);
 
-      await accountMonitor.stopMonitoring(subscriptionId);
+      await accountMonitor.stopMonitoring(params.address, params.network);
 
       expect(mockSubscriptionService.unsubscribe).toHaveBeenCalledWith(
-        subscriptionId,
+        mockSubscriptionId,
       );
+    });
+
+    it('doesnt fail if the subscription is not found', async () => {
+      await accountMonitor.stopMonitoring(params.address, params.network);
+
+      expect(mockSubscriptionService.unsubscribe).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/snap/src/core/test/mocks/solana-assets.ts
+++ b/packages/snap/src/core/test/mocks/solana-assets.ts
@@ -2,14 +2,11 @@
 import type { FungibleAssetMetadata } from '@metamask/snaps-sdk';
 import type { CaipAssetType } from '@metamask/utils';
 import { TOKEN_PROGRAM_ADDRESS, type Mint } from '@solana-program/token';
+import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 import type { Account } from '@solana/kit';
 import { address, lamports } from '@solana/kit';
 
-import {
-  KnownCaip19Id,
-  Network,
-  TOKEN_2022_PROGRAM_ADDRESS,
-} from '../../constants/solana';
+import { KnownCaip19Id, Network } from '../../constants/solana';
 import type { SolanaAsset } from '../../types/solana';
 
 export const SOLANA_MOCK_TOKEN: SolanaAsset = {


### PR DESCRIPTION
- When user deletes an account:
  - unsubscribe from it
  - unsubscribe from all its token accounts
- Standardize logging in the `AssetsService`