### PR TITLE
chore: replace console with logger

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "vs7hh2sR9VqVzhlkK4cVzTIo/tJry4Iwj8Bxwtfol74=",
+    "shasum": "xxsqokdmkZfn7mNMPm8ZPhx7Q0gt57raVtUKAd2IuXA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/caching/useCache.ts
+++ b/packages/snap/src/core/caching/useCache.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-void */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Serializable } from '../serialization/types';
+import logger from '../utils/logger';
 import type { ICache } from './ICache';
 
 /**
@@ -69,7 +70,7 @@ export const useCache = <TArgs extends any[], TResult extends Serializable>(
       }
     } catch (error) {
       // Log cache get errors but proceed to execute the function
-      console.error(`Cache get error for key "${cacheKey}":`, error);
+      logger.error(`Cache get error for key "${cacheKey}":`, error);
     }
 
     // Execute the original function
@@ -78,7 +79,7 @@ export const useCache = <TArgs extends any[], TResult extends Serializable>(
     // Cache the result, handle potential errors silently
     // We don't await this, allowing it to happen in the background
     void cache.set(cacheKey, result, ttlMilliseconds).catch((error) => {
-      console.error(`Cache set error for key "${cacheKey}":`, error);
+      logger.error(`Cache set error for key "${cacheKey}":`, error);
     });
 
     return result;

--- a/packages/snap/src/core/clients/nft-api/NftApiClient.test.ts
+++ b/packages/snap/src/core/clients/nft-api/NftApiClient.test.ts
@@ -3,7 +3,7 @@ import type { ICache } from '../../caching/ICache';
 import { InMemoryCache } from '../../caching/InMemoryCache';
 import type { Serializable } from '../../serialization/types';
 import type { ConfigProvider } from '../../services/config';
-import type { ILogger } from '../../utils/logger';
+import { mockLogger } from '../../services/mocks/logger';
 import { MOCK_NFT_METADATA_RESPONSE_MAPPED } from './mocks/mockNftMetadataResponseMapped';
 import { MOCK_NFT_METADATA_RESPONSE_RAW } from './mocks/mockNftMetadataResponseRaw';
 import { MOCK_NFTS_LIST_RESPONSE_MAPPED } from './mocks/mockNftsListResponseMapped';
@@ -11,11 +11,6 @@ import { MOCK_NFTS_LIST_RESPONSE_RAW } from './mocks/mockNftsListResponseRaw';
 import { NftApiClient } from './NftApiClient';
 
 const mockFetch = jest.fn();
-const mockLogger = {
-  info: jest.fn(console.info),
-  error: jest.fn(console.error),
-  warn: jest.fn(console.error),
-} as unknown as ILogger;
 let mockCache: ICache<Serializable>;
 
 describe('NftApiClient', () => {

--- a/packages/snap/src/core/clients/token-api-client/TokenApiClient.test.ts
+++ b/packages/snap/src/core/clients/token-api-client/TokenApiClient.test.ts
@@ -3,7 +3,7 @@
 import type { TokenCaipAssetType } from '../../constants/solana';
 import { KnownCaip19Id, Network } from '../../constants/solana';
 import type { ConfigProvider } from '../../services/config';
-import type { ILogger } from '../../utils/logger';
+import { mockLogger } from '../../services/mocks/logger';
 import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
 import { TokenApiClient } from './TokenApiClient';
 
@@ -26,10 +26,6 @@ const MOCK_METADATA_RESPONSE = [
 
 describe('TokenApiClient', () => {
   const mockFetch = jest.fn();
-  const mockLogger = {
-    error: jest.fn(console.error),
-    warn: jest.fn(console.error),
-  } as unknown as ILogger;
 
   let client: TokenApiClient;
   let mockConfigProvider: ConfigProvider;

--- a/packages/snap/src/core/utils/concurrency.ts
+++ b/packages/snap/src/core/utils/concurrency.ts
@@ -1,3 +1,5 @@
+import logger from './logger';
+
 export type CancellablePromise<ReturnType> = Promise<ReturnType> & {
   cancel: () => void;
 };
@@ -94,7 +96,7 @@ export function withoutConcurrency<ReturnType>(
     if (currentTask) {
       if (typeof currentTask.cancel === 'function') {
         const message = 'Cancelling previous task';
-        console.warn(message);
+        logger.warn(message);
         currentTask.cancel();
       }
     }

--- a/packages/snap/src/core/utils/formatCryptoBalance.ts
+++ b/packages/snap/src/core/utils/formatCryptoBalance.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js';
 
+import logger from './logger';
+
 const MIN_AMOUNT = 0.000001;
 const MAX_SIGNIFICANT_DECIMAL_PLACES = 3;
 const ZERO_DISPLAY = '0';
@@ -88,7 +90,7 @@ export function formatCryptoBalance(
 
     return formattedAmount;
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return ZERO_DISPLAY;
   }
 }

--- a/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
@@ -10,6 +10,7 @@ import {
   showDialog,
   updateInterface,
 } from '../../../../core/utils/interface';
+import logger from '../../../../core/utils/logger';
 import { extractInstructionsFromUnknownBase64String } from '../../../../entities';
 import {
   connection,
@@ -85,7 +86,7 @@ export async function render(
       context.advanced.instructions = instructions;
     })
     .catch((error) => {
-      console.error(error);
+      logger.error(error);
       context.advanced.instructions = [];
     });
 


### PR DESCRIPTION
Replace all instances where `console.*` was used with `logger.*`