### PR TITLE
fix:  buildUrl function with potential vulnerability

### DIFF
--- a/packages/snap/src/core/utils/buildUrl.test.ts
+++ b/packages/snap/src/core/utils/buildUrl.test.ts
@@ -39,6 +39,17 @@ describe('buildUrl', () => {
     expect(result).toBe('https://api.example.com/users/123');
   });
 
+  it('encodes path parameters to prevent path traversal attacks', () => {
+    const result = buildUrl({
+      baseUrl: 'https://api.example.com',
+      path: '/tokens/{assetId}',
+      pathParams: { assetId: 'solana:mainnet:token123' },
+    });
+    expect(result).toBe(
+      'https://api.example.com/tokens/solana%3Amainnet%3Atoken123',
+    );
+  });
+
   it('handles trailing slash in base URL', () => {
     const result = buildUrl({
       baseUrl: 'https://api.example.com/',
@@ -72,7 +83,7 @@ describe('buildUrl', () => {
     ).toThrow('URL contains potentially malicious patterns');
   });
 
-  it('prevents path traversal attacks', () => {
+  it('prevents path traversal attacks by encoding path parameters', () => {
     const result = buildUrl({
       baseUrl: 'https://api.example.com',
       path: '/../../../etc/passwd',

--- a/packages/snap/src/core/utils/buildUrl.ts
+++ b/packages/snap/src/core/utils/buildUrl.ts
@@ -29,7 +29,8 @@ export function buildUrl(params: BuildUrlParams): string {
     if (value === undefined) {
       throw new Error(`Path parameter ${key} is undefined`);
     }
-    return value;
+
+    return encodeURIComponent(value);
   });
 
   const cleanPath = pathWithParams


### PR DESCRIPTION
The `buildUrl` function had a Path Parameter Injection vulnerability where path parameters were directly replaced without encoding, allowing path traversal attacks to potentially break URL context and access unintended resources.
To fix this we've added `encodeURIComponent(value)`, to ensure special characters like `/, \, and %` are properly URL-encoded.