### PR TITLE
chore: validate address for Signin

### DIFF
--- a/packages/snap/src/core/services/wallet/WalletService.test.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.test.ts
@@ -207,6 +207,20 @@ describe('WalletService', () => {
         service.resolveAccountAddress(accounts, scope, request),
       ).rejects.toThrow('No accounts with this scope');
     });
+
+    it('rejects a SignIn request with an address that does not belong to the keyring accounts', async () => {
+      const request = {
+        ...MOCK_SIGN_IN_REQUEST,
+        params: {
+          ...MOCK_SIGN_IN_REQUEST.params,
+          address: 'non-existent-address',
+        },
+      } as unknown as SolanaWalletRequest;
+
+      await expect(
+        service.resolveAccountAddress(mockAccounts, scope, request),
+      ).rejects.toThrow('Account not found');
+    });
   });
 
   describe.each(MOCK_EXECUTION_SCENARIOS)(

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -126,29 +126,23 @@ export class WalletService {
       throw new Error('No accounts with this scope');
     }
 
+    let addressToValidate: string;
+
     switch (method) {
       case SolMethod.SignIn: {
         const { address } = params;
         if (!address) {
           throw new Error('No address');
         }
-        return addressToCaip10(scope, address);
+        addressToValidate = address;
+        break;
       }
       case SolMethod.SignAndSendTransaction:
       case SolMethod.SignMessage:
       case SolMethod.SignTransaction: {
         const { account } = params;
-
-        // Check if the account is in the list of accounts held in the keyring.
-        const address = accountsWithThisScope.find(
-          (a) => a.address === account.address,
-        )?.address;
-
-        if (!address) {
-          throw new Error('Account not found');
-        }
-
-        return addressToCaip10(scope, address);
+        addressToValidate = account.address;
+        break;
       }
       default: {
         // This code is unreachable because the "validateRequest" function
@@ -157,6 +151,16 @@ export class WalletService {
         throw new Error('Unsupported method');
       }
     }
+
+    const foundAccount = accountsWithThisScope.find(
+      (a) => a.address === addressToValidate,
+    );
+
+    if (!foundAccount) {
+      throw new Error('Account not found');
+    }
+
+    return addressToCaip10(scope, addressToValidate);
   }
 
   /**


### PR DESCRIPTION
The `SignIn` case only checked if the address existed but doesn't validate if it belongs to any of the keyring accounts.
Therefore we update the `SignIn` case in the `resolveAccountAddress` to also validate that the `address` belongs to one of the keyring accounts, like the other methods do.