### PR TITLE
chore: adds check and throws error

### DIFF
--- a/packages/snap/src/core/clients/price-api/PriceApiClient.test.ts
+++ b/packages/snap/src/core/clients/price-api/PriceApiClient.test.ts
@@ -346,7 +346,7 @@ describe('PriceApiClient', () => {
         });
 
         expect(mockFetch).toHaveBeenCalledWith(
-          'https://some-mock-url.com/v3/historical-prices/solana%3A5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp%2Fslip44%3A501?timePeriod=5d&from=123&to=456&vsCurrency=usd',
+          'https://some-mock-url.com/v3/historical-prices/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501?timePeriod=5d&from=123&to=456&vsCurrency=usd',
         );
         expect(cacheSetSpy).toHaveBeenCalledWith(
           'PriceApiClient:getHistoricalPrices:{"assetType":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501","timePeriod":"5d","from":123,"to":456,"vsCurrency":"usd"}',

--- a/packages/snap/src/core/clients/price-api/PriceApiClient.ts
+++ b/packages/snap/src/core/clients/price-api/PriceApiClient.ts
@@ -277,6 +277,7 @@ export class PriceApiClient {
       pathParams: {
         assetType: params.assetType,
       },
+      encodePathParams: false,
       queryParams: {
         ...(params.timePeriod && { timePeriod: params.timePeriod }),
         ...(params.from && { from: params.from.toString() }),

--- a/packages/snap/src/core/services/wallet/WalletService.test.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.test.ts
@@ -470,6 +470,23 @@ describe('WalletService', () => {
             /At path/u,
           );
         });
+
+        it('rejects when account address in request does not match signing account', async () => {
+          const account = MOCK_SOLANA_KEYRING_ACCOUNT_3;
+          const request = wrapKeyringRequest({
+            ...MOCK_SIGN_MESSAGE_REQUEST,
+            params: {
+              ...MOCK_SIGN_MESSAGE_REQUEST.params,
+              account: {
+                address: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,
+              },
+            },
+          } as unknown as JsonRpcRequest);
+
+          await expect(service.signMessage(account, request)).rejects.toThrow(
+            'The requested account and/or method has not been authorized by the user.',
+          );
+        });
       });
 
       describe('signIn', () => {

--- a/packages/snap/src/core/utils/buildUrl.test.ts
+++ b/packages/snap/src/core/utils/buildUrl.test.ts
@@ -126,4 +126,40 @@ describe('buildUrl', () => {
     });
     expect(result).toBe('https://api.example.com/path/to/resource');
   });
+
+  it('does not encode path parameters when encodePathParams is false', () => {
+    const result = buildUrl({
+      baseUrl: 'https://api.example.com',
+      path: '/tokens/{assetId}',
+      pathParams: { assetId: 'solana:mainnet:token123' },
+      encodePathParams: false,
+    });
+    expect(result).toBe(
+      'https://api.example.com/tokens/solana:mainnet:token123',
+    );
+  });
+  
+  it('encodes path parameters when encodePathParams is explicitly true', () => {
+    const result = buildUrl({
+      baseUrl: 'https://api.example.com',
+      path: '/tokens/{assetId}',
+      pathParams: { assetId: 'solana:mainnet:token123' },
+      encodePathParams: true,
+    });
+    expect(result).toBe(
+      'https://api.example.com/tokens/solana%3Amainnet%3Atoken123',
+    );
+  });
+  
+  it('maintains backward compatibility by encoding path parameters by default', () => {
+    const result = buildUrl({
+      baseUrl: 'https://api.example.com',
+      path: '/tokens/{assetId}',
+      pathParams: { assetId: 'solana:mainnet:token123' },
+      // encodePathParams not specified - should default to true
+    });
+    expect(result).toBe(
+      'https://api.example.com/tokens/solana%3Amainnet%3Atoken123',
+    );
+  });
 });

--- a/packages/snap/src/core/utils/buildUrl.ts
+++ b/packages/snap/src/core/utils/buildUrl.ts
@@ -7,6 +7,7 @@ export type BuildUrlParams = {
   path: string;
   pathParams?: Record<string, string> | undefined;
   queryParams?: Record<string, string> | undefined;
+  encodePathParams?: boolean;
 };
 
 /**
@@ -20,7 +21,13 @@ export type BuildUrlParams = {
  * @returns The built URL.
  */
 export function buildUrl(params: BuildUrlParams): string {
-  const { baseUrl, path, pathParams, queryParams } = params;
+  const {
+    baseUrl,
+    path,
+    pathParams,
+    queryParams,
+    encodePathParams = true,
+  } = params;
 
   assert(baseUrl, UrlStruct);
 
@@ -30,7 +37,7 @@ export function buildUrl(params: BuildUrlParams): string {
       throw new Error(`Path parameter ${key} is undefined`);
     }
 
-    return encodeURIComponent(value);
+    return encodePathParams ? encodeURIComponent(value) : value;
   });
 
   const cleanPath = pathWithParams


### PR DESCRIPTION
Two different topics in this PR:

- Checks that the account address in the request parameters matches the account used for signing and If it doesn't match, throw the same error MM throws when the account is not authorized. (Original solo goal)

- Fixes the `buildUrl` function, where we now add an optional parameter called `encodePathParams` so that Price API calls can set it to `false`, since it doesn't support the decoding of URL params.