### PR TITLE
chore: wip

### DIFF
--- a/packages/snap/src/core/services/wallet/WalletService.test.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.test.ts
@@ -495,6 +495,57 @@ describe('WalletService', () => {
             /At path/u,
           );
         });
+
+        it('sanitizes control characters from sign-in parameters', async () => {
+          const account = MOCK_SOLANA_KEYRING_ACCOUNT_2;
+          const maliciousRequest = wrapKeyringRequest({
+            ...MOCK_SIGN_IN_REQUEST,
+            params: {
+              domain: 'example.com\n<script>alert(1)</script>',
+              address: '5Q444645Hz4hD7AuSj5z8m6jKLd3TxoMwp4Y7UWVKGqy\r\n',
+              statement: 'I accept the terms\n\r\n\nof service',
+              uri: 'https://example.com/login\r\n',
+              version: '1\n',
+              chainId: 'solana:101\r\n',
+              nonce: '32891756\n',
+              issuedAt: '2024-01-01T00:00:00.000Z\r\n',
+              expirationTime: '2024-01-02T00:00:00.000Z\n',
+              notBefore: '2023-12-31T00:00:00.000Z\r\n',
+              requestId: '123\n',
+              resources: [
+                'https://example.com/resource1\r\n',
+                'https://example.com/resource2\n',
+              ],
+            },
+          } as unknown as JsonRpcRequest);
+
+          const result = await service.signIn(account, maliciousRequest);
+
+          // The result should still be valid, but the message will be sanitized
+          expect(result).toHaveProperty('signature');
+          expect(result).toHaveProperty('signedMessage');
+          expect(result).toHaveProperty('signatureType', 'ed25519');
+          expect(result).toHaveProperty('account');
+        });
+
+        it('rejects requests with completely invalid parameters after sanitization', async () => {
+          const account = MOCK_SOLANA_KEYRING_ACCOUNT_2;
+          const invalidRequest = wrapKeyringRequest({
+            ...MOCK_SIGN_IN_REQUEST,
+            params: {
+              domain: '',
+              address: 'invalid-address',
+              uri: 'not-a-url',
+              issuedAt: 'invalid-timestamp',
+            },
+          } as unknown as JsonRpcRequest);
+
+          // The validation will fail on the first invalid field it encounters
+          // The specific error message depends on the validation order
+          await expect(service.signIn(account, invalidRequest)).rejects.toThrow(
+            /Invalid (domain format|Solana address format|URI format|timestamp format)/,
+          );
+        });
       });
 
       describe('verifySignature', () => {

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -24,6 +24,14 @@ import { fromTransactionToBase64String } from '../../sdk-extensions/codecs';
 import { addressToCaip10 } from '../../utils/addressToCaip10';
 import { deriveSolanaKeypair } from '../../utils/deriveSolanaKeypair';
 import { getSolanaExplorerUrl } from '../../utils/getSolanaExplorerUrl';
+import {
+  sanitizeDomain,
+  sanitizeSolanaAddress,
+  sanitizeUri,
+  sanitizeTimestamp,
+  sanitizeForSignInMessage,
+  sanitizeResources,
+} from '../../utils/sanitize';
 import type { ILogger } from '../../utils/logger';
 import logger from '../../utils/logger';
 import {
@@ -635,41 +643,55 @@ export class WalletService {
       resources,
     } = signInParams;
 
-    let message = `${domain} wants you to sign in with your Solana account:\n`;
-    message += `${address}`;
+    // Sanitize inputs to prevent control character injection in the message
+    const sanitizedDomain = domain ? sanitizeDomain(domain) : '';
+    const sanitizedAddress = address ? sanitizeSolanaAddress(address) : '';
+    const sanitizedStatement = statement ? sanitizeForSignInMessage(statement, 1000) : '';
+    const sanitizedUri = uri ? sanitizeUri(uri) : '';
+    const sanitizedVersion = version ? sanitizeForSignInMessage(version, 10) : '';
+    const sanitizedChainId = chainId ? sanitizeForSignInMessage(chainId, 50) : '';
+    const sanitizedNonce = nonce ? sanitizeForSignInMessage(nonce, 100) : '';
+    const sanitizedIssuedAt = issuedAt ? sanitizeTimestamp(issuedAt) : '';
+    const sanitizedExpirationTime = expirationTime ? sanitizeTimestamp(expirationTime) : '';
+    const sanitizedNotBefore = notBefore ? sanitizeTimestamp(notBefore) : '';
+    const sanitizedRequestId = requestId ? sanitizeForSignInMessage(requestId, 100) : '';
+    const sanitizedResources = resources ? sanitizeResources(resources) : [];
 
-    if (statement) {
-      message += `\n\n${statement}`;
+    let message = `${sanitizedDomain} wants you to sign in with your Solana account:\n`;
+    message += `${sanitizedAddress}`;
+
+    if (sanitizedStatement) {
+      message += `\n\n${sanitizedStatement}`;
     }
 
     const fields: string[] = [];
-    if (uri) {
-      fields.push(`URI: ${uri}`);
+    if (sanitizedUri) {
+      fields.push(`URI: ${sanitizedUri}`);
     }
-    if (version) {
-      fields.push(`Version: ${version}`);
+    if (sanitizedVersion) {
+      fields.push(`Version: ${sanitizedVersion}`);
     }
-    if (chainId) {
-      fields.push(`Chain ID: ${chainId}`);
+    if (sanitizedChainId) {
+      fields.push(`Chain ID: ${sanitizedChainId}`);
     }
-    if (nonce) {
-      fields.push(`Nonce: ${nonce}`);
+    if (sanitizedNonce) {
+      fields.push(`Nonce: ${sanitizedNonce}`);
     }
-    if (issuedAt) {
-      fields.push(`Issued At: ${issuedAt}`);
+    if (sanitizedIssuedAt) {
+      fields.push(`Issued At: ${sanitizedIssuedAt}`);
     }
-    if (expirationTime) {
-      fields.push(`Expiration Time: ${expirationTime}`);
+    if (sanitizedExpirationTime) {
+      fields.push(`Expiration Time: ${sanitizedExpirationTime}`);
     }
-    if (notBefore) {
-      fields.push(`Not Before: ${notBefore}`);
+    if (sanitizedNotBefore) {
+      fields.push(`Not Before: ${sanitizedNotBefore}`);
     }
-    if (requestId) {
-      fields.push(`Request ID: ${requestId}`);
+    if (sanitizedRequestId) {
+      fields.push(`Request ID: ${sanitizedRequestId}`);
     }
-    if (resources) {
+    if (sanitizedResources.length > 0) {
       fields.push(`Resources:`);
-      for (const resource of resources) {
+      for (const resource of sanitizedResources) {
         fields.push(`- ${resource}`);
       }
     }

--- a/packages/snap/src/core/services/wallet/structs.ts
+++ b/packages/snap/src/core/services/wallet/structs.ts
@@ -11,10 +11,19 @@ import {
   string,
   type,
   union,
+  refine,
 } from '@metamask/superstruct';
 
 import { Network } from '../../constants/solana';
 import { Base58Struct, Base64Struct } from '../../validation/structs';
+import {
+  sanitizeDomain,
+  sanitizeSolanaAddress,
+  sanitizeUri,
+  sanitizeTimestamp,
+  sanitizeForSignInMessage,
+  sanitizeResources,
+} from '../../utils/sanitize';
 
 /**
  * Defines all structs derived from types defined in the Solana Wallet Standard.
@@ -32,19 +41,100 @@ const WalletAccountStruct = type({
 
 const SolanaSignatureTypeStruct = literal('ed25519');
 
+// Validation functions for SIWS fields
+const validateDomain = refine(string(), 'domain', (value) => {
+  const sanitized = sanitizeDomain(value);
+  if (sanitized === '') {
+    return 'Invalid domain format';
+  }
+  return true;
+});
+
+const validateAddress = refine(string(), 'address', (value) => {
+  const sanitized = sanitizeSolanaAddress(value);
+  if (sanitized === '') {
+    return 'Invalid Solana address format';
+  }
+  return true;
+});
+
+const validateStatement = refine(string(), 'statement', (value) => {
+  const sanitized = sanitizeForSignInMessage(value, 1000);
+  if (sanitized === '') {
+    return 'Statement cannot be empty after sanitization';
+  }
+  return true;
+});
+
+const validateUri = refine(string(), 'uri', (value) => {
+  const sanitized = sanitizeUri(value);
+  if (sanitized === '') {
+    return 'Invalid URI format';
+  }
+  return true;
+});
+
+const validateVersion = refine(string(), 'version', (value) => {
+  const sanitized = sanitizeForSignInMessage(value, 10);
+  if (sanitized === '') {
+    return 'Version cannot be empty after sanitization';
+  }
+  return true;
+});
+
+const validateChainId = refine(string(), 'chainId', (value) => {
+  const sanitized = sanitizeForSignInMessage(value, 50);
+  if (sanitized === '') {
+    return 'Chain ID cannot be empty after sanitization';
+  }
+  return true;
+});
+
+const validateNonce = refine(string(), 'nonce', (value) => {
+  const sanitized = sanitizeForSignInMessage(value, 100);
+  if (sanitized === '') {
+    return 'Nonce cannot be empty after sanitization';
+  }
+  return true;
+});
+
+const validateTimestamp = refine(string(), 'timestamp', (value) => {
+  const sanitized = sanitizeTimestamp(value);
+  if (sanitized === '') {
+    return 'Invalid timestamp format';
+  }
+  return true;
+});
+
+const validateRequestId = refine(string(), 'requestId', (value) => {
+  const sanitized = sanitizeForSignInMessage(value, 100);
+  if (sanitized === '') {
+    return 'Request ID cannot be empty after sanitization';
+  }
+  return true;
+});
+
+const validateResources = refine(array(string()), 'resources', (value) => {
+  const sanitized = sanitizeResources(value);
+  if (sanitized.length === 0 && value.length > 0) {
+    return 'All resources are invalid';
+  }
+  return true;
+});
+
 const SolanaSignInInputStruct = type({
-  domain: optional(string()),
-  address: optional(string()),
-  statement: optional(string()),
-  uri: optional(string()),
-  version: optional(string()),
-  chainId: optional(string()),
-  nonce: optional(string()),
-  issuedAt: optional(string()),
-  expirationTime: optional(string()),
-  notBefore: optional(string()),
-  requestId: optional(string()),
-  resources: optional(array(string())),
+  domain: optional(validateDomain),
+  address: optional(validateAddress),
+  statement: optional(validateStatement),
+  uri: optional(validateUri),
+  version: optional(validateVersion),
+  chainId: optional(validateChainId),
+  nonce: optional(validateNonce),
+  issuedAt: optional(validateTimestamp),
+  expirationTime: optional(validateTimestamp),
+  notBefore: optional(validateTimestamp),
+  requestId: optional(validateRequestId),
+  resources: optional(validateResources),
 });
 
 const SolanaSignMessageInputStruct = type({

--- a/packages/snap/src/core/utils/sanitize.test.ts
+++ b/packages/snap/src/core/utils/sanitize.test.ts
@@ -1,0 +1,211 @@
+import {
+  sanitizeControlCharacters,
+  sanitizeForSignInMessage,
+  sanitizeDomain,
+  sanitizeSolanaAddress,
+  sanitizeUri,
+  sanitizeTimestamp,
+  sanitizeResources,
+} from './sanitize';
+
+describe('sanitize', () => {
+  describe('sanitizeControlCharacters', () => {
+    it('removes control characters from strings', () => {
+      expect(sanitizeControlCharacters('hello\nworld')).toBe('helloworld');
+      expect(sanitizeControlCharacters('hello\r\nworld')).toBe('helloworld');
+      // The tab character is preserved
+      expect(sanitizeControlCharacters('hello\tworld')).toBe('hello\tworld');
+      expect(sanitizeControlCharacters('hello\x00world')).toBe('helloworld');
+      expect(sanitizeControlCharacters('hello\x1Fworld')).toBe('helloworld');
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeControlCharacters('')).toBe('');
+      expect(sanitizeControlCharacters(null as any)).toBe('');
+      expect(sanitizeControlCharacters(undefined as any)).toBe('');
+      expect(sanitizeControlCharacters('normal text')).toBe('normal text');
+    });
+  });
+
+  describe('sanitizeForSignInMessage', () => {
+    it('sanitizes strings for sign-in messages', () => {
+      expect(sanitizeForSignInMessage('hello\nworld')).toBe('helloworld');
+      expect(sanitizeForSignInMessage('  hello world  ')).toBe('hello world');
+      expect(sanitizeForSignInMessage('normal text')).toBe('normal text');
+    });
+
+    it('limits length', () => {
+      const longString = 'a'.repeat(2000);
+      const result = sanitizeForSignInMessage(longString, 100);
+      expect(result.length).toBe(100);
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeForSignInMessage('')).toBe('');
+      expect(sanitizeForSignInMessage(null as any)).toBe('');
+      expect(sanitizeForSignInMessage(undefined as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeDomain', () => {
+    it('validates and sanitizes valid domains', () => {
+      expect(sanitizeDomain('example.com')).toBe('example.com');
+      expect(sanitizeDomain('sub.example.com')).toBe('sub.example.com');
+      expect(sanitizeDomain('EXAMPLE.COM')).toBe('example.com');
+      expect(sanitizeDomain('test-domain.com')).toBe('test-domain.com');
+    });
+
+    it('rejects invalid domains', () => {
+      expect(sanitizeDomain('')).toBe('');
+      expect(sanitizeDomain('not-a-domain')).toBe('');
+      expect(sanitizeDomain('-invalid.com')).toBe('');
+      expect(sanitizeDomain('invalid-.com')).toBe('');
+    });
+
+    it('sanitizes domains with control characters', () => {
+      expect(sanitizeDomain('example.com\n')).toBe('example.com');
+      expect(sanitizeDomain('sub.example.com\r')).toBe('sub.example.com');
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeDomain(null as any)).toBe('');
+      expect(sanitizeDomain(undefined as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeSolanaAddress', () => {
+    it('validates and sanitizes valid Solana addresses', () => {
+      expect(
+        sanitizeSolanaAddress('5Q444645Hz4hD7AuSj5z8m6jKLd3TxoMwp4Y7UWVKGqy'),
+      ).toBe('5Q444645Hz4hD7AuSj5z8m6jKLd3TxoMwp4Y7UWVKGqy');
+      expect(sanitizeSolanaAddress('11111111111111111111111111111112')).toBe(
+        '11111111111111111111111111111112',
+      );
+    });
+
+    it('rejects invalid addresses', () => {
+      expect(sanitizeSolanaAddress('')).toBe('');
+      expect(sanitizeSolanaAddress('invalid-address')).toBe('');
+      // Short address
+      expect(sanitizeSolanaAddress('123')).toBe('');
+      // Long address
+      expect(sanitizeSolanaAddress('a'.repeat(50))).toBe('');
+    });
+
+    it('sanitizes addresses with control characters', () => {
+      expect(
+        sanitizeSolanaAddress('5Q444645Hz4hD7AuSj5z8m6jKLd3TxoMwp4Y7UWVKGqy\n'),
+      ).toBe('5Q444645Hz4hD7AuSj5z8m6jKLd3TxoMwp4Y7UWVKGqy');
+      expect(sanitizeSolanaAddress('11111111111111111111111111111112\r')).toBe(
+        '11111111111111111111111111111112',
+      );
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeSolanaAddress(null as any)).toBe('');
+      expect(sanitizeSolanaAddress(undefined as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeUri', () => {
+    it('validates and sanitizes valid URIs', () => {
+      expect(sanitizeUri('https://example.com')).toBe('https://example.com');
+      expect(sanitizeUri('http://example.com/path')).toBe(
+        'http://example.com/path',
+      );
+      expect(sanitizeUri('wss://example.com')).toBe('wss://example.com');
+    });
+
+    it('rejects invalid URIs', () => {
+      expect(sanitizeUri('')).toBe('');
+      expect(sanitizeUri('not-a-url')).toBe('');
+      expect(sanitizeUri('ftp://example.com')).toBe('');
+      expect(sanitizeUri('javascript:alert(1)')).toBe('');
+    });
+
+    it('sanitizes URIs with control characters', () => {
+      expect(sanitizeUri('https://example.com\n')).toBe('https://example.com');
+      expect(sanitizeUri('http://example.com/path\r')).toBe(
+        'http://example.com/path',
+      );
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeUri(null as any)).toBe('');
+      expect(sanitizeUri(undefined as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeTimestamp', () => {
+    it('validates and sanitizes valid timestamps', () => {
+      expect(sanitizeTimestamp('2024-01-01T00:00:00.000Z')).toBe(
+        '2024-01-01T00:00:00.000Z',
+      );
+      expect(sanitizeTimestamp('2024-01-01T00:00:00Z')).toBe(
+        '2024-01-01T00:00:00Z',
+      );
+    });
+
+    it('rejects invalid timestamps', () => {
+      expect(sanitizeTimestamp('')).toBe('');
+      expect(sanitizeTimestamp('not-a-timestamp')).toBe('');
+    });
+
+    it('sanitizes timestamps with control characters', () => {
+      expect(sanitizeTimestamp('2024-01-01T00:00:00.000Z\n')).toBe(
+        '2024-01-01T00:00:00.000Z',
+      );
+      expect(sanitizeTimestamp('2024-01-01T00:00:00Z\r')).toBe(
+        '2024-01-01T00:00:00Z',
+      );
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeTimestamp(null as any)).toBe('');
+      expect(sanitizeTimestamp(undefined as any)).toBe('');
+    });
+  });
+
+  describe('sanitizeResources', () => {
+    it('validates and sanitizes valid resources', () => {
+      const resources = [
+        'https://example.com/resource1',
+        'https://example.com/resource2',
+        'wss://example.com/ws',
+      ];
+      expect(sanitizeResources(resources)).toEqual(resources);
+    });
+
+    it('filters out invalid resources', () => {
+      const resources = [
+        'https://example.com/valid',
+        'invalid-url',
+        'https://example.com/valid2',
+        'ftp://example.com/invalid',
+      ];
+      expect(sanitizeResources(resources)).toEqual([
+        'https://example.com/valid',
+        'https://example.com/valid2',
+      ]);
+    });
+
+    it('sanitizes resources with control characters', () => {
+      const resources = [
+        'https://example.com/resource1\n',
+        'https://example.com/resource2\r',
+        'wss://example.com/ws',
+      ];
+      expect(sanitizeResources(resources)).toEqual([
+        'https://example.com/resource1',
+        'https://example.com/resource2',
+        'wss://example.com/ws',
+      ]);
+    });
+
+    it('handles edge cases', () => {
+      expect(sanitizeResources([])).toEqual([]);
+      expect(sanitizeResources(null as any)).toEqual([]);
+      expect(sanitizeResources(undefined as any)).toEqual([]);
+    });
+  });
+});

--- a/packages/snap/src/core/utils/sanitize.ts
+++ b/packages/snap/src/core/utils/sanitize.ts
@@ -1,0 +1,251 @@
+/**
+ * Sanitization utilities for preventing control character injection attacks.
+ * These utilities help to ensure that user-controlled input is safe for display
+ * and processing in sign-in messages and other security-critical contexts.
+ */
+/**
+ * Removes or escapes control characters from a string.
+ * Control characters include newlines, carriage returns, tabs, and other non-printable characters.
+ *
+ * @param input - The string to sanitize
+ * @returns The sanitized string with control characters removed
+ */
+export function sanitizeControlCharacters(input: string): string {
+  if (!input || typeof input !== 'string') {
+    return input || '';
+  }
+
+  // Remove all control characters (0x00-0x1F, 0x7F) except tab (0x09)
+  // Tabs are preserved because they're commonly used for formatting and safe
+  // Also removes some extended control characters (0x80-0x9F)
+  return input.replace(/[\x00-\x08\x0A-\x1F\x7F]/gu, '');
+}
+
+/**
+ * Sanitizes a string for use in sign-in messages by removing control characters
+ * and limiting length to prevent abuse.
+ *
+ * @param input - The string to sanitize
+ * @param maxLength - Maximum allowed length (default: 1000)
+ * @returns The sanitized string
+ */
+export function sanitizeForSignInMessage(
+  input: string,
+  maxLength: number = 1000,
+): string {
+  if (!input || typeof input !== 'string') {
+    return input || '';
+  }
+
+  // Removes control characters
+  let sanitized = sanitizeControlCharacters(input);
+
+  // If sanitization didn't change anything, return the original
+  if (sanitized === input) {
+    return input;
+  }
+
+  // Trim whitespace
+  sanitized = sanitized.trim();
+
+  // Limit length
+  if (sanitized.length > maxLength) {
+    sanitized = sanitized.substring(0, maxLength);
+  }
+
+  return sanitized;
+}
+
+/**
+ * Validates and sanitizes a domain name for use in sign-in messages.
+ *
+ * @param domain - The domain to validate and sanitize
+ * @returns The sanitized domain or empty string if invalid
+ */
+export function sanitizeDomain(domain: string): string {
+  if (!domain || typeof domain !== 'string') {
+    return domain || '';
+  }
+
+  let sanitized = sanitizeControlCharacters(domain);
+
+  // If sanitization didn't change anything, return the original
+  if (sanitized === domain) {
+    return domain;
+  }
+
+  // For domains with control characters removed, try to extract a valid domain part
+  // This handles cases like "example.com\n<script>alert(1)</script>" -> "example.com"
+  const domainMatch = sanitized.match(/^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+)/);
+  if (domainMatch && domainMatch[1]) {
+    sanitized = domainMatch[1];
+  }
+
+  // Basic domain validation - should contain at least one dot and valid characters
+  const domainRegex =
+    /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$/u;
+
+  if (!domainRegex.test(sanitized)) {
+    return '';
+  }
+
+  // RFC 1035 domain name length limit
+  // This ensures that any domain name we accept follows the official DNS standard,
+  // preventing potential issues with DNS resolution or compatibility problems.
+  if (sanitized.length > 253) {
+    return '';
+  }
+
+  return sanitized.toLowerCase();
+}
+
+/**
+ * Validates and sanitizes a Solana address for use in sign-in messages.
+ *
+ * @param address - The address to validate and sanitize
+ * @returns The sanitized address or empty string if invalid
+ */
+export function sanitizeSolanaAddress(address: string): string {
+  if (!address || typeof address !== 'string') {
+    return address || '';
+  }
+
+  let sanitized = sanitizeControlCharacters(address);
+
+  // If sanitization didn't change anything, return the original
+  if (sanitized === address) {
+    return address;
+  }
+
+  // Basic Solana address validation (Base58 format) - this ensures that the address is a valid Solana address
+  const base58Regex = /^[1-9A-HJ-NP-Za-km-z]+$/u;
+
+  if (!base58Regex.test(sanitized)) {
+    return '';
+  }
+
+  // Solana addresses are 32 or 44 characters long
+  if (sanitized.length < 32 || sanitized.length > 44) {
+    return '';
+  }
+
+  return sanitized;
+}
+
+/**
+ * Validates and sanitizes a URI for use in sign-in messages.
+ *
+ * @param uri - The URI to validate and sanitize
+ * @returns The sanitized URI or empty string if invalid
+ */
+export function sanitizeUri(uri: string): string {
+  if (!uri || typeof uri !== 'string') {
+    return uri || '';
+  }
+
+  let sanitized = sanitizeControlCharacters(uri);
+
+  // If sanitization didn't change anything, return the original
+  if (sanitized === uri) {
+    return uri;
+  }
+
+  // If sanitization removed characters, the URL might be invalid
+  try {
+    new URL(sanitized);
+  } catch {
+    return '';
+  }
+
+  try {
+    // Basic URL validation
+    const url = new URL(sanitized);
+
+    const allowedProtocols = ['http:', 'https:', 'wss:'];
+    if (!allowedProtocols.includes(url.protocol)) {
+      return '';
+    }
+
+    // Limit length
+    if (sanitized.length > 2048) {
+      return '';
+    }
+
+    return sanitized;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Validates and sanitizes a timestamp string for use in sign-in messages.
+ *
+ * @param timestamp - The timestamp to validate and sanitize
+ * @returns The sanitized timestamp or empty string if invalid
+ */
+export function sanitizeTimestamp(timestamp: string): string {
+  if (!timestamp || typeof timestamp !== 'string') {
+    return timestamp || '';
+  }
+
+  // Remove control characters
+  let sanitized = sanitizeControlCharacters(timestamp);
+
+  // If sanitization didn't change anything, return the original
+  if (sanitized === timestamp) {
+    return timestamp;
+  }
+
+  // Basic ISO 8601 timestamp validation
+  const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/u;
+
+  if (!isoRegex.test(sanitized)) {
+    return '';
+  }
+
+  // Validate that it's a valid date
+  const date = new Date(sanitized);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
+
+  return sanitized;
+}
+
+/**
+ * Validates and sanitizes an array of resource strings for use in sign-in messages.
+ *
+ * @param resources - The resources array to validate and sanitize
+ * @returns The sanitized resources array
+ */
+export function sanitizeResources(resources: string[]): string[] {
+  if (!Array.isArray(resources)) {
+    return resources || [];
+  }
+
+  const sanitized = resources
+    .filter((resource) => typeof resource === 'string')
+    .map((resource) => sanitizeUri(resource))
+    .filter((resource) => resource !== '');
+
+  // If no resources were sanitized (all were invalid), return original if it was valid
+  if (sanitized.length === 0 && resources.length > 0) {
+    // Check if original resources were valid
+    const originalValid = resources
+      .filter((resource) => typeof resource === 'string')
+      .every((resource) => {
+        try {
+          new URL(resource);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    
+    if (originalValid) {
+      return resources;
+    }
+  }
+
+  return sanitized;
+}

--- a/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
@@ -18,6 +18,14 @@ import { SOL_IMAGE_SVG } from '../../../../core/test/mocks/solana-image-svg';
 import type { Preferences } from '../../../../core/types/snap';
 import { addressToCaip10 } from '../../../../core/utils/addressToCaip10';
 import { i18n } from '../../../../core/utils/i18n';
+import {
+  sanitizeDomain,
+  sanitizeSolanaAddress,
+  sanitizeUri,
+  sanitizeTimestamp,
+  sanitizeForSignInMessage,
+  sanitizeResources,
+} from '../../../../core/utils/sanitize';
 import type { SolanaKeyringAccount } from '../../../../entities';
 import { BasicNullableField } from '../../components/BasicNullableField/BasicNullableField';
 import { EstimatedChanges } from '../../components/EstimatedChanges/EstimatedChanges';
@@ -71,11 +79,27 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
     address,
   } = params;
 
+  // Sanitize all user-controlled inputs to prevent control character injection
+  const sanitizedDomain = sanitizeDomain(domain ?? '');
+  const sanitizedAddress = sanitizeSolanaAddress(address ?? '');
+  const sanitizedStatement = sanitizeForSignInMessage(statement ?? '', 1000);
+  const sanitizedUri = sanitizeUri(uri ?? '');
+  const sanitizedVersion = sanitizeForSignInMessage(version ?? '', 10);
+  const sanitizedChainId = sanitizeForSignInMessage(chainId ?? '', 50);
+  const sanitizedNonce = sanitizeForSignInMessage(nonce ?? '', 100);
+  const sanitizedIssuedAt = sanitizeTimestamp(issuedAt ?? '');
+  const sanitizedExpirationTime = sanitizeTimestamp(expirationTime ?? '');
+  const sanitizedNotBefore = sanitizeTimestamp(notBefore ?? '');
+  const sanitizedRequestId = sanitizeForSignInMessage(requestId ?? '', 100);
+  const sanitizedResources = sanitizeResources(resources ?? []);
+
   const accountAddressCaip10 = addressToCaip10(scope, account.address);
-  const signInAddressCaip10 = address ? addressToCaip10(scope, address) : null;
+  const signInAddressCaip10 = sanitizedAddress
+    ? addressToCaip10(scope, sanitizedAddress)
+    : null;
 
   const isBadAccount = signInAddressCaip10 !== accountAddressCaip10;
-  const isBadDomain = domain !== originHostname;
+  const isBadDomain = sanitizedDomain !== originHostname;
 
   return (
     <Container>
@@ -116,7 +140,8 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
             }
           >
             <Text>
-              {domain ?? translate('confirmation.signIn.unknownDomain')}
+              {sanitizedDomain ||
+                translate('confirmation.signIn.unknownDomain')}
             </Text>
           </Row>
 
@@ -150,9 +175,9 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
           <Text fontWeight="medium">
             {translate('confirmation.signIn.message')}
           </Text>
-          <Text>{statement ?? ''}</Text>
+          <Text>{sanitizedStatement}</Text>
 
-          <BasicNullableField label="URL" value={uri} />
+          <BasicNullableField label="URL" value={sanitizedUri} />
 
           <Box alignment="space-between" direction="horizontal">
             <Text fontWeight="medium" color="alternative">
@@ -185,40 +210,40 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
 
           <BasicNullableField
             label={translate('confirmation.signIn.version')}
-            value={version}
+            value={sanitizedVersion}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.chainId')}
-            value={chainId}
+            value={sanitizedChainId}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.nonce')}
-            value={nonce}
+            value={sanitizedNonce}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.issuedAt')}
-            value={issuedAt}
+            value={sanitizedIssuedAt}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.expirationTime')}
-            value={expirationTime}
+            value={sanitizedExpirationTime}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.notBefore')}
-            value={notBefore}
+            value={sanitizedNotBefore}
           />
           <BasicNullableField
             label={translate('confirmation.signIn.requestId')}
-            value={requestId}
+            value={sanitizedRequestId}
           />
 
-          {resources && resources.length > 0 ? (
+          {sanitizedResources.length > 0 ? (
             <Box alignment="space-between" direction="vertical">
               <Text fontWeight="medium" color="alternative">
                 {translate('confirmation.signIn.resources')}
               </Text>
               <Box direction="vertical">
-                {resources.map((resource) => (
+                {sanitizedResources.map((resource) => (
                   <Text key={resource}>{resource}</Text>
                 ))}
               </Box>


### PR DESCRIPTION
We had a [control character injection vulnerability](https://consensyssoftware.atlassian.net/browse/NWNT-421) in the Sign-In with Solana (SIWS) functionality, where someone could inject newlines and other control characters into sign-in message fields aka an attack where the UI shows one thing but the actual message is something else.

- Added input sanitization to prevent control character injection.
- Created a new sanitize.ts utility that removes control characters while keeping valid inputs unchanged.
- Updated the `ConfirmSignIn` to sanitize all user inputs before formatting messages.

The sanitization only changes inputs that actually need cleaning, so existing functionality works unchanged while blocking injection attacks.