### PR TITLE
Adds transfer-checked for token-2022 mints

### DIFF
--- a/packages/snap/src/features/send/transactions/SendSplTokenBuilder.ts
+++ b/packages/snap/src/features/send/transactions/SendSplTokenBuilder.ts
@@ -6,6 +6,7 @@ import {
 import {
   findAssociatedTokenPda,
   getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
   getTransferInstruction,
 } from '@solana-program/token';
 import type { CompilableTransactionMessage } from '@solana/kit';
@@ -117,12 +118,14 @@ export class SendSplTokenBuilder implements ISendTransactionBuilder {
               owner: to,
               ata: toTokenAccountAddress,
             }),
-            getTransferInstruction(
+            getTransferCheckedInstruction(
               {
                 source: fromTokenAccountAddress,
+                mint: mint,
                 destination: toTokenAccountAddress,
                 authority: signer,
-                amount: amountInTokenUnits,
+               amount: amountInTokenUnits,
+               decimals: decimals
               },
               {
                 programAddress: tokenProgram,


### PR DESCRIPTION
Use transferChecked in place of transfer.
The Token-2022 program does not support the transfer instruction, it has been replaced by the safer transfer_checked, which is also supported by the SPL Token Program,  thus the transaction fails.
It can be fixed with a simple change:

- Changed the getTransferInstruction function to the getTransferCheckedInstruction function