### PR TITLE
chore: Excessive Data Access and Prolonged Sensitive Information Exposure

### DIFF
--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
@@ -628,13 +628,11 @@ export class SolanaKeyring implements Keyring {
 
       const derivationPath = this.#getDefaultDerivationPath(groupIndex);
 
-      const keypair = await deriveSolanaKeypair({
+      const { publicKeyBytes } = await deriveSolanaKeypair({
         entropySource,
         derivationPath,
       });
-      const address = getAddressDecoder().decode(
-        keypair.publicKeyBytes.slice(1),
-      );
+      const address = getAddressDecoder().decode(publicKeyBytes.slice(1));
 
       const activityChecksPromises = [];
 

--- a/packages/snap/src/core/services/execution/TransactionHelper.ts
+++ b/packages/snap/src/core/services/execution/TransactionHelper.ts
@@ -300,13 +300,6 @@ export class TransactionHelper {
     account: SolanaKeyringAccount,
     scope: Network,
   ): Promise<Readonly<Transaction & TransactionWithLifetime>> {
-    const { privateKeyBytes } = await deriveSolanaKeypair({
-      entropySource: account.entropySource,
-      derivationPath: account.derivationPath,
-    });
-    const signer =
-      await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
-
     // First, make sure the transaction message has a fee payer, lifetime constraint and compute unit price
     const hasLifetimeConstraint =
       isTransactionMessageWithBlockhashLifetime(transactionMessage);
@@ -331,6 +324,13 @@ export class TransactionHelper {
      */
     const shouldSetComputeUnitLimit =
       !hasComputeUnitLimit || !hasComputeUnitPrice;
+
+    const { privateKeyBytes } = await deriveSolanaKeypair({
+      entropySource: account.entropySource,
+      derivationPath: account.derivationPath,
+    });
+    const signer =
+      await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
 
     const compilableTransactionMessage = await pipe(
       transactionMessage,

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -373,6 +373,7 @@ export class WalletService {
     const { message } = request.request.params;
     const messageBytes = getBase64Codec().encode(message);
     const messageUtf8 = getUtf8Codec().decode(messageBytes);
+    const signableMessage = createSignableMessage(messageUtf8);
 
     const { privateKeyBytes } = await deriveSolanaKeypair({
       entropySource,
@@ -381,8 +382,6 @@ export class WalletService {
 
     const signer =
       await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
-
-    const signableMessage = createSignableMessage(messageUtf8);
 
     const [messageSignatureBytesMap] = await signer.signMessages([
       signableMessage,
@@ -492,6 +491,11 @@ export class WalletService {
     assert(signatureBase58, Base58Struct);
     assert(messageBase64, Base64Struct);
 
+    const signatureBytes = getBase58Codec().encode(
+      signatureBase58,
+    ) as SignatureBytes;
+    const messageBytes = getBase64Codec().encode(messageBase64);
+
     const { privateKeyBytes } = await deriveSolanaKeypair({
       entropySource: account.entropySource,
       derivationPath: account.derivationPath,
@@ -499,12 +503,6 @@ export class WalletService {
 
     const signer =
       await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
-
-    const signatureBytes = getBase58Codec().encode(
-      signatureBase58,
-    ) as SignatureBytes;
-
-    const messageBytes = getBase64Codec().encode(messageBase64);
 
     const verified = await verifySignature(
       signer.keyPair.publicKey,


### PR DESCRIPTION
- Moved private key derivation as late as possible, performing the validations and operations before deriving the sensitive key parts.
- Optimized `renderSend` replacing `get()` (which retrieves entire application state) with individual `getKey()` calls for only the required fields.
