### PR TITLE
fix: refresh crons

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "8ufRG4iBVewqxExSv+Ri41hNIHkWbdWamb0dy9J08Cw=",
+    "shasum": "A/ROrjUIlJ60+Q7bXdvlVAV4scbyyFGKa9ugl14g190=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "hHujqCkO64mNxMSFHMgapQvEaP5iazwZauTlB2zp9iU=",
+    "shasum": "dnCl/VNoLdGKROoLT/Y/4D9Od6HoiqI+Pto8naSbPfw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "A/ROrjUIlJ60+Q7bXdvlVAV4scbyyFGKa9ugl14g190=",
+    "shasum": "hHujqCkO64mNxMSFHMgapQvEaP5iazwZauTlB2zp9iU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "dnCl/VNoLdGKROoLT/Y/4D9Od6HoiqI+Pto8naSbPfw=",
+    "shasum": "K6WM41X4AIT62Esep4eK3X2y3lt7gOYBDtoDEhp+O90=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -33,23 +33,20 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     return;
   }
 
-  // Schedule the next run
-  await snap.request({
-    method: 'snap_scheduleBackgroundEvent',
-    params: {
-      duration: 'PT20S',
-      request: { method: 'refreshConfirmationEstimation' },
-    },
-  });
+  // Get the current context
+  const interfaceContext =
+    await getInterfaceContextOrThrow<ConfirmTransactionRequestContext>(
+      confirmationInterfaceId,
+    );
+
+  // Don't do anything if the interface context is not found
+  if (!interfaceContext) {
+    logger.info(`No interface context found`);
+    return;
+  }
 
   // Update the interface context with the new rates.
   try {
-    // Get the current context
-    const interfaceContext =
-      await getInterfaceContextOrThrow<ConfirmTransactionRequestContext>(
-        confirmationInterfaceId,
-      );
-
     if (
       !interfaceContext.account?.address ||
       !interfaceContext.transaction ||
@@ -107,6 +104,15 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     );
 
     logger.info(`Background event suceeded`);
+
+    // Schedule the next run
+    await snap.request({
+      method: 'snap_scheduleBackgroundEvent',
+      params: {
+        duration: 'PT20S',
+        request: { method: 'refreshConfirmationEstimation' },
+      },
+    });
   } catch (error) {
     const fetchedInterfaceContext =
       await getInterfaceContextOrThrow<ConfirmTransactionRequestContext>(
@@ -124,8 +130,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       fetchingConfirmationContext,
     );
 
-    logger.info(
-      { error },
+    logger.warn(
       `Could not update the interface. But rolled back status to fetched.`,
     );
   }

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -6,6 +6,7 @@ import { state, transactionScanService } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
   CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME,
+  getInterfaceContext,
   getInterfaceContextOrThrow,
   updateInterface,
 } from '../../../utils/interface';
@@ -35,7 +36,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
 
   // Get the current context
   const interfaceContext =
-    await getInterfaceContextOrThrow<ConfirmTransactionRequestContext>(
+    await getInterfaceContext<ConfirmTransactionRequestContext>(
       confirmationInterfaceId,
     );
 

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -131,6 +131,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     );
 
     logger.warn(
+      { error },
       `Could not update the interface. But rolled back status to fetched.`,
     );
   }

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -6,7 +6,6 @@ import { state, transactionScanService } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
   CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME,
-  getInterfaceContext,
   getInterfaceContextOrThrow,
   updateInterface,
 } from '../../../utils/interface';
@@ -36,15 +35,9 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
 
   // Get the current context
   const interfaceContext =
-    await getInterfaceContext<ConfirmTransactionRequestContext>(
+    await getInterfaceContextOrThrow<ConfirmTransactionRequestContext>(
       confirmationInterfaceId,
     );
-
-  // Don't do anything if the interface context is not found
-  if (!interfaceContext) {
-    logger.info(`No interface context found`);
-    return;
-  }
 
   // Update the interface context with the new rates.
   try {

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
@@ -6,7 +6,7 @@ import type { SendContext } from '../../../../features/send/types';
 import { assetsService, priceApiClient, state } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
-  getInterfaceContextOrThrow,
+  getInterfaceContext,
   getPreferences,
   SEND_FORM_INTERFACE_NAME,
   updateInterface,
@@ -36,11 +36,15 @@ export const refreshSend: OnCronjobHandler = async () => {
     return;
   }
 
-  // Schedule the next run
-  await snap.request({
-    method: 'snap_scheduleBackgroundEvent',
-    params: { duration: 'PT30S', request: { method: 'refreshSend' } },
-  });
+  // Get the current context
+  const interfaceContext =
+    await getInterfaceContext<SendContext>(sendFormInterfaceId);
+
+  // Don't do anything if the interface context is not found
+  if (!interfaceContext) {
+    logger.info(`No interface context found`);
+    return;
+  }
 
   // First, fetch the token prices
   const tokenPrices = await priceApiClient.getMultipleSpotPrices(
@@ -50,21 +54,6 @@ export const refreshSend: OnCronjobHandler = async () => {
 
   // Save them in the state
   await state.setKey('tokenPrices', tokenPrices);
-
-  // Get the current context
-  const interfaceContext =
-    await getInterfaceContextOrThrow<SendContext>(sendFormInterfaceId);
-
-  // We only want to refresh the token prices when the user is in the transaction confirmation stage
-  if (interfaceContext.stage !== 'transaction-confirmation') {
-    logger.info(`❌ Not in transaction confirmation stage`);
-    return;
-  }
-
-  if (!interfaceContext.assets) {
-    logger.info(`❌ No assets found`);
-    return;
-  }
 
   // Update the current context with the new rates
   const updatedInterfaceContext = {
@@ -82,4 +71,10 @@ export const refreshSend: OnCronjobHandler = async () => {
   );
 
   logger.info(`✅ Background event suceeded`);
+
+  // Schedule the next run
+  await snap.request({
+    method: 'snap_scheduleBackgroundEvent',
+    params: { duration: 'PT30S', request: { method: 'refreshSend' } },
+  });
 };

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
@@ -6,7 +6,7 @@ import type { SendContext } from '../../../../features/send/types';
 import { assetsService, priceApiClient, state } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
-  getInterfaceContext,
+  getInterfaceContextOrThrow,
   getPreferences,
   SEND_FORM_INTERFACE_NAME,
   updateInterface,
@@ -38,13 +38,7 @@ export const refreshSend: OnCronjobHandler = async () => {
 
   // Get the current context
   const interfaceContext =
-    await getInterfaceContext<SendContext>(sendFormInterfaceId);
-
-  // Don't do anything if the interface context is not found
-  if (!interfaceContext) {
-    logger.info(`No interface context found`);
-    return;
-  }
+    await getInterfaceContextOrThrow<SendContext>(sendFormInterfaceId);
 
   // First, fetch the token prices
   const tokenPrices = await priceApiClient.getMultipleSpotPrices(

--- a/packages/snap/src/features/send/views/TransactionConfirmation/events.tsx
+++ b/packages/snap/src/features/send/views/TransactionConfirmation/events.tsx
@@ -167,6 +167,9 @@ async function onConfirmButtonClick({
 
   // Finally, show the transaction-complete or transaction-failed stage
   await updateInterface(id, <Send context={updatedContext} />, updatedContext);
+
+  // Clean up the interface name to id map
+  await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
 }
 
 export const eventHandlers = {


### PR DESCRIPTION
## Fix background event scheduling in send flow when UI is closed

### Problem
- In some cases, the `refreshSend` background event was continuing to run even when the UI was closed/interface context no longer existed
- This caused unnecessary processing and potential errors when trying to update non-existent interfaces
- Events were being scheduled before successful completion, leading to continued execution even on failures

### Changes

**Background Event Handling:**
- Added interface context existence checks in both `refreshConfirmationEstimation` and `refreshSend` handlers
- If no interface context is found (UI closed), the background events now exit early without scheduling the next run
- Moved background event scheduling to occur *after* successful interface updates rather than at the beginning
- Properly remove the interface id from the state after transaction success / failure


### Result
Now `refreshSend` properly terminates when the UI is closed + on transaction success / failure, preventing unnecessary processing. Events only continue running when there's an active interface to update.