### PR TITLE
fix: bump send SPL compute unit limit

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "K6WM41X4AIT62Esep4eK3X2y3lt7gOYBDtoDEhp+O90=",
+    "shasum": "KYRZwy5xyJvWnFQ6rKI5S21yHbkUoD9Xa7vh94P9HDc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/features/send/transactions/SendSplTokenBuilder.test.ts
+++ b/packages/snap/src/features/send/transactions/SendSplTokenBuilder.test.ts
@@ -116,7 +116,7 @@ describe('SendSplTokenBuilder', () => {
         },
         instructions: [
           {
-            data: new Uint8Array([2, 48, 117, 0, 0]),
+            data: new Uint8Array([2, 64, 156, 0, 0]),
             programAddress: 'ComputeBudget111111111111111111111111111111',
           },
           {

--- a/packages/snap/src/features/send/transactions/SendSplTokenBuilder.ts
+++ b/packages/snap/src/features/send/transactions/SendSplTokenBuilder.ts
@@ -43,10 +43,11 @@ export class SendSplTokenBuilder implements ISendTransactionBuilder {
   readonly #logger: ILogger;
 
   /**
-   * The transaction built here always consumes less than 30,000 compute units,
-   * even in the case where we need to create the recepient's associated token account.
+   * The transaction built here consumes up to ~30,000 compute units when just transferring
+   * to an existing associated token account, but requires ~35,000+ compute units when
+   * creating the recipient's associated token account.
    */
-  readonly #computeUnitLimit = 30_000;
+  readonly #computeUnitLimit = 40_000;
 
   readonly #computeUnitPriceMicroLamportsPerComputeUnit = 10000n;
 


### PR DESCRIPTION
While testing the send flow by sending random tokens to a bunch of accounts, I found cases where the 30k compute unit limit we use isn't sufficient, causing the transaction to fail.

This bumps the limit higher so that we don't hit the limit anymore.