### PR TITLE
feat: unified send flow methods

### DIFF
--- a/packages/snap/openrpc.json
+++ b/packages/snap/openrpc.json
@@ -100,6 +100,415 @@
           }
         }
       ]
+    },
+    {
+      "name": "onConfirmSend",
+      "summary": "Confirm and execute a send transaction",
+      "description": "Confirms and executes a send transaction with the specified parameters. This method validates the request parameters and submits the transaction to the Solana network.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "fromAccountId",
+          "summary": "The UUID of the account to send from",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Uuid"
+          }
+        },
+        {
+          "name": "toAddress",
+          "summary": "The Solana address to send to",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SolanaAddress"
+          }
+        },
+        {
+          "name": "amount",
+          "summary": "The amount to send as a positive number string",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/PositiveNumberString"
+          }
+        },
+        {
+          "name": "assetId",
+          "summary": "The CAIP-19 asset identifier",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CaipAssetType"
+          }
+        }
+      ],
+      "result": {
+        "name": "OnConfirmSendResult",
+        "summary": "The result of confirming and executing the send transaction",
+        "schema": {
+          "$ref": "#/components/schemas/SignAndSendTransactionResult"
+        }
+      },
+      "examples": [
+        {
+          "name": "onConfirmSendExample",
+          "description": "Example of confirming a SOL send transaction",
+          "params": [
+            {
+              "name": "fromAccountId",
+              "value": "c747acb9-1b2b-4352-b9da-3d658fcc3cc7"
+            },
+            {
+              "name": "toAddress",
+              "value": "BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP"
+            },
+            {
+              "name": "amount",
+              "value": "1.5"
+            },
+            {
+              "name": "assetId",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+            }
+          ],
+          "result": {
+            "name": "onConfirmSendResult",
+            "value": {
+              "signature": "2jy9nsDuajiPgRRijs7Ku4JVvTFQ224Nhoc58fe72tRoy384JAF6zVWFV2SwTt9XXykxes6LkU6VLokn6wAXTocQ"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "onAddressInput",
+      "summary": "Validate a Solana address input",
+      "description": "Validates a Solana address input and returns validation results. This method checks if the provided address is a valid Solana address format.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "value",
+          "summary": "The address string to validate",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ValidationResponse",
+        "summary": "The validation result for the address input",
+        "schema": {
+          "$ref": "#/components/schemas/ValidationResponse"
+        }
+      },
+      "examples": [
+        {
+          "name": "onAddressInputExample",
+          "description": "Example of validating a valid Solana address",
+          "params": [
+            {
+              "name": "value",
+              "value": "BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP"
+            }
+          ],
+          "result": {
+            "name": "validationResponse",
+            "value": {
+              "valid": true,
+              "errors": []
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "onAmountInput",
+      "summary": "Validate an amount input for a transaction",
+      "description": "Validates an amount input for a transaction and returns validation results. This method checks if the amount is valid based on account balance, fees, and other constraints.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "value",
+          "summary": "The amount string to validate",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/PositiveNumberString"
+          }
+        },
+        {
+          "name": "accountId",
+          "summary": "The UUID of the account to validate against",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Uuid"
+          }
+        },
+        {
+          "name": "assetId",
+          "summary": "The CAIP-19 asset identifier to validate against",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/CaipAssetType"
+          }
+        }
+      ],
+      "result": {
+        "name": "ValidationResponse",
+        "summary": "The validation result for the amount input",
+        "schema": {
+          "$ref": "#/components/schemas/ValidationResponse"
+        }
+      },
+      "examples": [
+        {
+          "name": "onAmountInputExample",
+          "description": "Example of validating a valid amount input",
+          "params": [
+            {
+              "name": "value",
+              "value": "1.5"
+            },
+            {
+              "name": "accountId",
+              "value": "c747acb9-1b2b-4352-b9da-3d658fcc3cc7"
+            },
+            {
+              "name": "assetId",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+            }
+          ],
+          "result": {
+            "name": "validationResponse",
+            "value": {
+              "valid": true,
+              "errors": []
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "startSendTransactionFlow",
+      "summary": "Start the send transaction flow interface",
+      "description": "Initiates the send transaction flow by rendering the send form interface. This method creates a user interface for sending transactions.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "scope",
+          "summary": "The Solana network scope",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Network"
+          }
+        },
+        {
+          "name": "account",
+          "summary": "The UUID of the account to send from",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Uuid"
+          }
+        },
+        {
+          "name": "assetId",
+          "summary": "Optional CAIP-19 asset identifier",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/CaipAssetType"
+          }
+        }
+      ],
+      "result": {
+        "name": "StartSendTransactionFlowResult",
+        "summary": "The result of starting the send transaction flow",
+        "schema": {
+          "type": "object",
+          "description": "Interface ID for the created send form"
+        }
+      },
+      "examples": [
+        {
+          "name": "startSendTransactionFlowExample",
+          "description": "Example of starting a send transaction flow for SOL",
+          "params": [
+            {
+              "name": "scope",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            },
+            {
+              "name": "account",
+              "value": "c747acb9-1b2b-4352-b9da-3d658fcc3cc7"
+            },
+            {
+              "name": "assetId",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+            }
+          ],
+          "result": {
+            "name": "startSendTransactionFlowResult",
+            "value": {
+              "interfaceId": "sendTransactionForm"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "getFeeForTransaction",
+      "summary": "Get the fee for a transaction",
+      "description": "Calculates and returns the fee for a given transaction in lamports. This method helps users understand the cost of their transaction before execution.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction",
+          "summary": "The base64-encoded transaction to calculate fees for",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "scope",
+          "summary": "The Solana network scope",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Network"
+          }
+        }
+      ],
+      "result": {
+        "name": "GetFeeForTransactionResult",
+        "summary": "The fee for the transaction in lamports",
+        "schema": {
+          "$ref": "#/components/schemas/GetFeeForTransactionResult"
+        }
+      },
+      "examples": [
+        {
+          "name": "getFeeForTransactionExample",
+          "description": "Example of getting the fee for a transaction",
+          "params": [
+            {
+              "name": "transaction",
+              "value": "gAEAAgSZsAKPnZ6vMobike0KV4I/ucjxTM1cFYhLnVhPWfjfdN2zrulHQhiUvVcoUaPML7MFkgDu9PV2PudQFNTACzusAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAHWszLmyDo8VIk2P/sVmDUn34YE2+73fS1kNLCNojDEqAwMABQIsAQAAAwAJA+gDAAAAAAAAAgIAAQwCAAAAQEIPAAAAAAAA"
+            },
+            {
+              "name": "scope",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            }
+          ],
+          "result": {
+            "name": "getFeeForTransactionResult",
+            "value": {
+              "value": "15000"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "getGenesisHash",
+      "summary": "Get the genesis hash for a Solana network",
+      "description": "Retrieves the genesis hash for the specified Solana network. This method provides network-specific information.",
+      "paramStructure": "by-name",
+      "params": [],
+      "result": {
+        "name": "GetGenesisHashResult",
+        "summary": "The genesis hash for the network",
+        "schema": {
+          "type": "string",
+          "description": "The genesis hash as a string"
+        }
+      },
+      "examples": [
+        {
+          "name": "getGenesisHashExample",
+          "description": "Example of getting the genesis hash for mainnet",
+          "params": [],
+          "result": {
+            "name": "genesisHash",
+            "value": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+          }
+        }
+      ]
+    },
+    {
+      "name": "getLatestBlockhash",
+      "summary": "Get the latest blockhash for a Solana network",
+      "description": "Retrieves the latest blockhash for the specified Solana network. This method provides current network state information.",
+      "paramStructure": "by-name",
+      "params": [],
+      "result": {
+        "name": "GetLatestBlockhashResult",
+        "summary": "The latest blockhash for the network",
+        "schema": {
+          "type": "string",
+          "description": "The latest blockhash as a string"
+        }
+      },
+      "examples": [
+        {
+          "name": "getLatestBlockhashExample",
+          "description": "Example of getting the latest blockhash",
+          "params": [],
+          "result": {
+            "name": "latestBlockhash",
+            "value": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+          }
+        }
+      ]
+    },
+    {
+      "name": "getMinimumBalanceForRentExemption",
+      "summary": "Get the minimum balance for rent exemption",
+      "description": "Retrieves the minimum balance required for rent exemption on the specified Solana network.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "dataLength",
+          "summary": "The length of data in bytes",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        {
+          "name": "commitment",
+          "summary": "Optional commitment level",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/TransactionCommitment"
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMinimumBalanceForRentExemptionResult",
+        "summary": "The minimum balance for rent exemption in lamports",
+        "schema": {
+          "type": "string",
+          "description": "The minimum balance as a string"
+        }
+      },
+      "examples": [
+        {
+          "name": "getMinimumBalanceForRentExemptionExample",
+          "description": "Example of getting minimum balance for rent exemption",
+          "params": [
+            {
+              "name": "dataLength",
+              "value": 1000
+            },
+            {
+              "name": "commitment",
+              "value": "confirmed"
+            }
+          ],
+          "result": {
+            "name": "minimumBalance",
+            "value": "890880"
+          }
+        }
+      ]
     }
   ],
   "components": {
@@ -114,12 +523,32 @@
         "description": "A base58-encoded string",
         "pattern": "^[1-9A-HJ-NP-Za-km-z]+$"
       },
+      "Uuid": {
+        "type": "string",
+        "description": "A UUID string in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      },
+      "PositiveNumberString": {
+        "type": "string",
+        "description": "A positive number as a string, excluding leading zeros",
+        "pattern": "^(?!0\\d)(\\d+(\\.\\d+)?)$"
+      },
+      "SolanaAddress": {
+        "type": "string",
+        "description": "A valid Solana address",
+        "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"
+      },
+      "CaipAssetType": {
+        "type": "string",
+        "description": "A CAIP-19 asset type identifier",
+        "pattern": "^[a-z]+:[0-9a-f]+(/[a-z]+:[0-9a-f]+)*$"
+      },
       "WalletAccount": {
         "type": "object",
         "description": "A wallet account containing the address",
         "properties": {
           "address": {
-            "type": "string",
+            "$ref": "#/components/schemas/SolanaAddress",
             "description": "The base58-encoded public key address of the account"
           }
         },
@@ -180,6 +609,54 @@
           }
         },
         "required": ["signature"],
+        "additionalProperties": false
+      },
+      "ValidationResponse": {
+        "type": "object",
+        "description": "Response from validation methods",
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "description": "Whether the input is valid"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Array of validation errors",
+            "items": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "$ref": "#/components/schemas/SendErrorCode"
+                }
+              },
+              "required": ["code"],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": ["valid", "errors"],
+        "additionalProperties": false
+      },
+      "SendErrorCode": {
+        "type": "string",
+        "description": "Error codes for send validation",
+        "enum": [
+          "Required",
+          "Invalid",
+          "InsufficientBalanceToCoverFee",
+          "InsufficientBalance"
+        ]
+      },
+      "GetFeeForTransactionResult": {
+        "type": "object",
+        "description": "Result of getting transaction fee",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The fee amount in lamports as a string"
+          }
+        },
+        "required": ["value"],
         "additionalProperties": false
       }
     }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "xKrq6KIYdl3bEo3sue45nSo9ensIp7Ljo3QFcN56OMU=",
+    "shasum": "Yb0VwmTIqBI+ddf1sawaDIT1V5u+dYssK2X4aZ4RgMg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/constants/solana.ts
+++ b/packages/snap/src/core/constants/solana.ts
@@ -8,6 +8,7 @@ export const MICRO_LAMPORTS_PER_LAMPORTS = 1_000_000n;
 export const LAMPORTS_PER_SOL = 1_000_000_000;
 export const DEFAULT_NETWORK_BLOCK_EXPLORER_URL = 'https://solscan.io';
 export const METAMASK_ORIGIN = 'metamask';
+export const METAMASK_ORIGIN_URL = 'https://metamask.io';
 
 /**
  * Solana CAIP-2 Networks

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
@@ -1,6 +1,8 @@
-import type { JsonRpcRequest } from '@metamask/snaps-sdk';
+import { InvalidParamsError, type JsonRpcRequest } from '@metamask/snaps-sdk';
 
-import { Network } from '../../constants/solana';
+import { KnownCaip19Id, Network } from '../../constants/solana';
+import type { SendService } from '../../services/send/SendService';
+import type { ValidationResponse } from '../../services/send/types';
 import type { SolanaSignAndSendTransactionResponse } from '../../services/wallet/structs';
 import type { WalletService } from '../../services/wallet/WalletService';
 import { MOCK_SOLANA_KEYRING_ACCOUNT_0 } from '../../test/mocks/solana-keyring-accounts';
@@ -14,6 +16,7 @@ describe('ClientRequestHandler', () => {
   let mockKeyring: jest.Mocked<SolanaKeyring>;
   let mockWalletService: jest.Mocked<WalletService>;
   let mockLogger: jest.Mocked<ILogger>;
+  let sendService: jest.Mocked<SendService>;
 
   beforeEach(() => {
     // Create mock keyring
@@ -31,11 +34,18 @@ describe('ClientRequestHandler', () => {
       log: jest.fn(),
     } as unknown as jest.Mocked<ILogger>;
 
+    sendService = {
+      onAmountInput: jest.fn(),
+      onAddressInput: jest.fn(),
+      confirmSend: jest.fn(),
+    } as unknown as jest.Mocked<SendService>;
+
     // Create handler instance
     handler = new ClientRequestHandler(
       mockKeyring,
       mockWalletService,
       mockLogger,
+      sendService,
     );
 
     // Reset all mocks
@@ -57,115 +67,269 @@ describe('ClientRequestHandler', () => {
         );
       });
     });
+  });
 
-    describe('when request to method signAndSendTransactionWithoutConfirmation', () => {
-      const mockTransaction =
-        'gAEAChfds67pR0IYlL1XKFGjzC+zBZIA7vT1dj7nUBTUwAs7rBn3hrWmXImk+UetGwvWumZpcEhF+xT5THD5os2Svp67H8GdfJ4jkOslaYOff/X0SeF33Cha5Ij9DKlo3QaosfIhtgnDmdJAVdjfmyv5dEGsSWgYEYPaqW8v8hSJozhYIzcQa4p5MinFjNMq4vDm+n249hE5Vmwe+Adkq87GTDegPbdaVhuqlrT5hZnIkdcW67eCFvm9ZzXM9jeWm2GwnLBGfnLp6qHLD5IgtqLXr5clzwoa2ns4KdysosGA2yFHt2dBBA/kB6qwUEagfnGzH2GY12XE3va/gn3W4Loqy/D+gP5PMjWwL4nGY8i3EGxqLHt/i3x/EskcO1ftQjYqQtqMVVDE+U/Vngb6x6+HbBOGrDQOx73j0k813TrK9dmptLgHDBoOIz6tGmWT+r9wa3YtqouLIv01/IKynGlc4TnE0M2MheikqA6gkuj1PhXVDgPc7eSLCseVMCy/WUgTmKbXmnZ/QcH3X8YTJ//GR4yvL7LCHdfHPhS8B+4hpoFusQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKD0N0oI1T+8K47DiJ9N82JyiZvsX3fj3y3zO++Tr3FVRPixdukLDvYMw2r2DTumX5VA1ifoAVfXgkOTnLswDEoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAC0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6LwHxW5grT0/F3OC6sZUj7of0yz9kMoCs+fPoYX9znOYyUOdJ8PoWqEFw7H8n7xwkhg1P1tPfo1/6arncTl4PJkEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwan1RcYx3TJKFZjmGkdXraLXrijm0ttXHNVWyEAAAAA0LlMW0o1bBeKH7IjSDuI9G0a+7kgVaW9ubbU+rklS9sFDgIWFAkAi8sXoE0wggARAAUCuIEWABEACAMgoQcAAAAAEAYACAATDS0BARVDLQ8ABgUECCoTFRUSFSslKyIjBQooKiQrDy0tKSsMAwEVKyErHB0KBygsHisPLS0pKx8gFScPJhsHBBcZGi0JGAILFSzBIJszQdacgQMDAAAAJmQAASZkAQIaZAIDQEIPAAAAAAC78khRAQAAADIAAANOgLKSmCyUmuksqMclFoVdtmiFizz7/yF11zNd6TSAxgUkIB4dIwIhIrYRAfelfqMdEh4JHXx6VS3GXpyeWhNKQlBsx9m2I8c+BhMSEBEUWgDdfctSzc+t7n0tohMIoz7S6USQkKhKDRCUSx6C3SjhJQQJAg8EBgoMCwYQBw==';
+  describe('signAndSendTransactionWithoutConfirmation', () => {
+    const mockTransaction =
+      'gAEAChfds67pR0IYlL1XKFGjzC+zBZIA7vT1dj7nUBTUwAs7rBn3hrWmXImk+UetGwvWumZpcEhF+xT5THD5os2Svp67H8GdfJ4jkOslaYOff/X0SeF33Cha5Ij9DKlo3QaosfIhtgnDmdJAVdjfmyv5dEGsSWgYEYPaqW8v8hSJozhYIzcQa4p5MinFjNMq4vDm+n249hE5Vmwe+Adkq87GTDegPbdaVhuqlrT5hZnIkdcW67eCFvm9ZzXM9jeWm2GwnLBGfnLp6qHLD5IgtqLXr5clzwoa2ns4KdysosGA2yFHt2dBBA/kB6qwUEagfnGzH2GY12XE3va/gn3W4Loqy/D+gP5PMjWwL4nGY8i3EGxqLHt/i3x/EskcO1ftQjYqQtqMVVDE+U/Vngb6x6+HbBOGrDQOx73j0k813TrK9dmptLgHDBoOIz6tGmWT+r9wa3YtqouLIv01/IKynGlc4TnE0M2MheikqA6gkuj1PhXVDgPc7eSLCseVMCy/WUgTmKbXmnZ/QcH3X8YTJ//GR4yvL7LCHdfHPhS8B+4hpoFusQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKD0N0oI1T+8K47DiJ9N82JyiZvsX3fj3y3zO++Tr3FVRPixdukLDvYMw2r2DTumX5VA1ifoAVfXgkOTnLswDEoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAC0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6LwHxW5grT0/F3OC6sZUj7of0yz9kMoCs+fPoYX9znOYyUOdJ8PoWqEFw7H8n7xwkhg1P1tPfo1/6arncTl4PJkEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwan1RcYx3TJKFZjmGkdXraLXrijm0ttXHNVWyEAAAAA0LlMW0o1bBeKH7IjSDuI9G0a+7kgVaW9ubbU+rklS9sFDgIWFAkAi8sXoE0wggARAAUCuIEWABEACAMgoQcAAAAAEAYACAATDS0BARVDLQ8ABgUECCoTFRUSFSslKyIjBQooKiQrDy0tKSsMAwEVKyErHB0KBygsHisPLS0pKx8gFScPJhsHBBcZGi0JGAILFSzBIJszQdacgQMDAAAAJmQAASZkAQIaZAIDQEIPAAAAAAC78khRAQAAADIAAANOgLKSmCyUmuksqMclFoVdtmiFizz7/yF11zNd6TSAxgUkIB4dIwIhIrYRAfelfqMdEh4JHXx6VS3GXpyeWhNKQlBsx9m2I8c+BhMSEBEUWgDdfctSzc+t7n0tohMIoz7S6USQkKhKDRCUSx6C3SjhJQQJAg8EBgoMCwYQBw==';
 
-      const validRequest: JsonRpcRequest = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: ClientRequestMethod.SignAndSendTransactionWithoutConfirmation,
-        params: {
-          account: {
-            address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
-          },
-          scope: Network.Testnet,
-          transaction: mockTransaction,
-          options: {
+    const validRequest: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: ClientRequestMethod.SignAndSendTransactionWithoutConfirmation,
+      params: {
+        account: {
+          address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        },
+        scope: Network.Testnet,
+        transaction: mockTransaction,
+        options: {
+          commitment: 'confirmed',
+          skipPreflight: false,
+          maxRetries: 3,
+        },
+      },
+    };
+
+    describe('when request is valid', () => {
+      beforeEach(() => {
+        mockKeyring.listAccounts.mockResolvedValue([
+          MOCK_SOLANA_KEYRING_ACCOUNT_0,
+        ]);
+      });
+
+      it('calls the wallet service and returns the response', async () => {
+        const expectedResponse: SolanaSignAndSendTransactionResponse = {
+          signature: 'transaction-signature',
+        };
+        mockWalletService.signAndSendTransaction.mockResolvedValue(
+          expectedResponse,
+        );
+
+        const response = await handler.handle(validRequest);
+
+        expect(mockWalletService.signAndSendTransaction).toHaveBeenCalledWith(
+          MOCK_SOLANA_KEYRING_ACCOUNT_0,
+          mockTransaction,
+          Network.Testnet,
+          'metamask',
+          {
             commitment: 'confirmed',
             skipPreflight: false,
             maxRetries: 3,
           },
+        );
+
+        expect(response).toStrictEqual(expectedResponse);
+      });
+
+      it('propagates wallet service errors', async () => {
+        const walletServiceError = new Error('Transaction failed');
+        mockWalletService.signAndSendTransaction.mockRejectedValue(
+          walletServiceError,
+        );
+
+        await expect(handler.handle(validRequest)).rejects.toThrow(
+          'Transaction failed',
+        );
+      });
+    });
+
+    describe('when the account is not found', () => {
+      it('throws an account not found error', async () => {
+        mockKeyring.listAccounts.mockResolvedValue([]);
+
+        await expect(handler.handle(validRequest)).rejects.toThrow(
+          `Account not found: ${MOCK_SOLANA_KEYRING_ACCOUNT_0.address}`,
+        );
+      });
+    });
+
+    describe('when the method is invalid', () => {
+      it('throws a method not found error', async () => {
+        const invalidRequest: JsonRpcRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'invalid_method' as ClientRequestMethod,
+          params: [],
+        };
+
+        await expect(handler.handle(invalidRequest)).rejects.toThrow(
+          'The method does not exist / is not available.',
+        );
+      });
+    });
+
+    describe('when the params are invalid', () => {
+      it('throws a invalid params error', async () => {
+        const invalidRequest: JsonRpcRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: ClientRequestMethod.SignAndSendTransactionWithoutConfirmation,
+          params: {
+            name: 'Alice',
+          },
+        };
+
+        await expect(handler.handle(invalidRequest)).rejects.toThrow(
+          'Invalid method parameter(s).',
+        );
+      });
+    });
+  });
+
+  describe('onConfirmSend', () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: ClientRequestMethod.OnConfirmSend,
+      params: {
+        fromAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        toAddress: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        amount: '10',
+        assetId: KnownCaip19Id.UsdcMainnet,
+      },
+    };
+
+    it('calls the send service and returns the response', async () => {
+      const response = {
+        pending: false,
+        result: {
+          signature: 'transaction-signature',
         },
       };
 
-      describe('when request is valid', () => {
-        beforeEach(() => {
-          mockKeyring.listAccounts.mockResolvedValue([
-            MOCK_SOLANA_KEYRING_ACCOUNT_0,
-          ]);
-        });
+      jest.spyOn(sendService, 'confirmSend').mockResolvedValue(response);
 
-        it('calls the wallet service and returns the response', async () => {
-          const expectedResponse: SolanaSignAndSendTransactionResponse = {
-            signature: 'transaction-signature',
-          };
-          mockWalletService.signAndSendTransaction.mockResolvedValue(
-            expectedResponse,
-          );
+      const result = await handler.handle(request);
 
-          const response = await handler.handle(validRequest);
+      expect(sendService.confirmSend).toHaveBeenCalledWith(request);
+      expect(result).toStrictEqual(response);
+    });
 
-          expect(mockWalletService.signAndSendTransaction).toHaveBeenCalledWith(
-            MOCK_SOLANA_KEYRING_ACCOUNT_0,
-            mockTransaction,
-            Network.Testnet,
-            'metamask',
-            {
-              commitment: 'confirmed',
-              skipPreflight: false,
-              maxRetries: 3,
-            },
-          );
+    it('propagates send service errors', async () => {
+      const sendServiceError = new Error('Transaction failed');
+      jest
+        .spyOn(sendService, 'confirmSend')
+        .mockRejectedValue(sendServiceError);
 
-          expect(response).toStrictEqual(expectedResponse);
-        });
+      await expect(handler.handle(request)).rejects.toThrow(
+        'Transaction failed',
+      );
+    });
 
-        it('should propagate wallet service errors', async () => {
-          const walletServiceError = new Error('Transaction failed');
-          mockWalletService.signAndSendTransaction.mockRejectedValue(
-            walletServiceError,
-          );
+    it('validates the request if invalid params are provided', async () => {
+      const invalidRequest: JsonRpcRequest = {
+        ...request,
+        params: {
+          fromAccountId: 'invalid-account-id',
+          toAddress: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+          amount: '10',
+          assetId: KnownCaip19Id.UsdcMainnet,
+        },
+      };
 
-          await expect(handler.handle(validRequest)).rejects.toThrow(
-            'Transaction failed',
-          );
-        });
-      });
+      await expect(handler.handle(invalidRequest)).rejects.toThrow(
+        InvalidParamsError,
+      );
+    });
+  });
 
-      describe('when the account is not found', () => {
-        it('throws an account not found error', async () => {
-          mockKeyring.listAccounts.mockResolvedValue([]);
+  describe('onAddressInput', () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: ClientRequestMethod.OnAddressInput,
+      params: {
+        value: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+      },
+    };
 
-          await expect(handler.handle(validRequest)).rejects.toThrow(
-            `Account not found: ${MOCK_SOLANA_KEYRING_ACCOUNT_0.address}`,
-          );
-        });
-      });
+    it('calls the send service and returns the response', async () => {
+      const response = {
+        valid: true,
+        errors: [],
+      };
 
-      describe('when the method is invalid', () => {
-        it('throws a method not found error', async () => {
-          const invalidRequest: JsonRpcRequest = {
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'invalid_method' as ClientRequestMethod,
-            params: [],
-          };
+      jest.spyOn(sendService, 'onAddressInput').mockResolvedValue(response);
 
-          await expect(handler.handle(invalidRequest)).rejects.toThrow(
-            'The method does not exist / is not available.',
-          );
-        });
-      });
+      const result = await handler.handle(request);
 
-      describe('when the params are invalid', () => {
-        it('throws a invalid params error', async () => {
-          const invalidRequest: JsonRpcRequest = {
-            jsonrpc: '2.0',
-            id: 1,
-            method:
-              ClientRequestMethod.SignAndSendTransactionWithoutConfirmation,
-            params: {
-              name: 'Alice',
-            },
-          };
+      expect(sendService.onAddressInput).toHaveBeenCalledWith(request);
+      expect(result).toStrictEqual(response);
+    });
 
-          await expect(handler.handle(invalidRequest)).rejects.toThrow(
-            'Invalid method parameter(s).',
-          );
-        });
-      });
+    it('throws an error if value is not provided', async () => {
+      const emptyValueRequest: JsonRpcRequest = {
+        ...request,
+        params: {
+          value: null,
+        },
+      };
+
+      await expect(handler.handle(emptyValueRequest)).rejects.toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('validates the response if invalid', async () => {
+      const response = {
+        property: 'invalid',
+      } as unknown as ValidationResponse;
+
+      jest.spyOn(sendService, 'onAddressInput').mockResolvedValue(response);
+
+      await expect(handler.handle(request)).rejects.toThrow(/At path: valid/iu);
+    });
+  });
+
+  describe('onAmountInput', () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: ClientRequestMethod.OnAmountInput,
+      params: {
+        value: '10',
+        accountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        assetId: KnownCaip19Id.UsdcMainnet,
+      },
+    };
+
+    it('calls the send service and returns the response', async () => {
+      const response = {
+        valid: true,
+        errors: [],
+      };
+
+      jest.spyOn(sendService, 'onAmountInput').mockResolvedValue(response);
+
+      const result = await handler.handle(request);
+
+      expect(sendService.onAmountInput).toHaveBeenCalledWith(request);
+      expect(result).toStrictEqual(response);
+    });
+
+    it('throws an error if value is not provided', async () => {
+      const emptyValueRequest: JsonRpcRequest = {
+        ...request,
+        params: {
+          value: null,
+        },
+      };
+
+      await expect(handler.handle(emptyValueRequest)).rejects.toThrow(
+        InvalidParamsError,
+      );
+    });
+
+    it('validates the response if invalid', async () => {
+      const response = {
+        property: 'invalid',
+      } as unknown as ValidationResponse;
+
+      jest.spyOn(sendService, 'onAmountInput').mockResolvedValue(response);
+
+      await expect(handler.handle(request)).rejects.toThrow(/At path: valid/iu);
     });
   });
 });

--- a/packages/snap/src/core/handlers/onClientRequest/types.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/types.ts
@@ -1,3 +1,6 @@
 export enum ClientRequestMethod {
   SignAndSendTransactionWithoutConfirmation = 'signAndSendTransactionWithoutConfirmation',
+  OnConfirmSend = 'onConfirmSend',
+  OnAddressInput = 'onAddressInput',
+  OnAmountInput = 'onAmountInput',
 }

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -1,10 +1,24 @@
 import { literal } from '@metamask/snaps-sdk';
-import { object } from '@metamask/superstruct';
-import { JsonRpcIdStruct, JsonRpcVersionStruct } from '@metamask/utils';
+import type { Infer } from '@metamask/superstruct';
+import { array, object, string, boolean, enums } from '@metamask/superstruct';
+import {
+  CaipAssetTypeStruct,
+  JsonRpcIdStruct,
+  JsonRpcVersionStruct,
+} from '@metamask/utils';
 
+import { SendErrorCodes } from '../../services/send/types';
 import { SolanaSignAndSendTransactionInputStruct } from '../../services/wallet/structs';
+import {
+  PositiveNumberStringStruct,
+  SolanaAddressStruct,
+  UuidStruct,
+} from '../../validation/structs';
 import { ClientRequestMethod } from './types';
 
+/**
+ * signAndSendTransactionWithoutConfirmation request/response validation.
+ */
 export const SignAndSendTransactionWithoutConfirmationRequestStruct = object({
   jsonrpc: JsonRpcVersionStruct,
   id: JsonRpcIdStruct,
@@ -13,3 +27,61 @@ export const SignAndSendTransactionWithoutConfirmationRequestStruct = object({
   ),
   params: SolanaSignAndSendTransactionInputStruct,
 });
+
+/**
+ * onConfirmSend request/response validation.
+ */
+export const OnConfirmSendRequestParamsStruct = object({
+  fromAccountId: UuidStruct,
+  toAddress: SolanaAddressStruct,
+  amount: PositiveNumberStringStruct,
+  assetId: CaipAssetTypeStruct,
+});
+
+export const OnConfirmSendRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.OnConfirmSend),
+  params: OnConfirmSendRequestParamsStruct,
+});
+
+/**
+ * onAddressInput request/response validation.
+ */
+export const OnAddressInputRequestParamsStruct = object({
+  value: string(),
+});
+
+export const OnAddressInputRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.OnAddressInput),
+  params: OnAddressInputRequestParamsStruct,
+});
+
+/**
+ * onAmountInput request/response validation.
+ */
+export const OnAmountInputRequestParamsStruct = object({
+  value: PositiveNumberStringStruct,
+  accountId: UuidStruct,
+  assetId: CaipAssetTypeStruct,
+});
+
+export const OnAmountInputRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.OnAmountInput),
+  params: OnAmountInputRequestParamsStruct,
+});
+
+export const ValidationResponseStruct = object({
+  valid: boolean(),
+  errors: array(
+    object({
+      code: enums(Object.values(SendErrorCodes)),
+    }),
+  ),
+});
+
+export type ValidationResponse = Infer<typeof ValidationResponseStruct>;

--- a/packages/snap/src/core/services/send/SendService.test.ts
+++ b/packages/snap/src/core/services/send/SendService.test.ts
@@ -1,0 +1,548 @@
+import { SolMethod } from '@metamask/keyring-api';
+import { lamports } from '@solana/kit';
+
+import type { AssetEntity, SolanaKeyringAccount } from '../../../entities';
+import type { SendSolBuilder } from '../../../features/send/transactions/SendSolBuilder';
+import type { SendSplTokenBuilder } from '../../../features/send/transactions/SendSplTokenBuilder';
+import type { ICache } from '../../caching/ICache';
+import { InMemoryCache } from '../../caching/InMemoryCache';
+import {
+  METAMASK_ORIGIN,
+  Networks,
+  Network,
+  KnownCaip19Id,
+} from '../../constants/solana';
+import { ClientRequestMethod } from '../../handlers/onClientRequest/types';
+import type { SolanaKeyring } from '../../handlers/onKeyringRequest/Keyring';
+import { fromCompilableTransactionMessageToBase64String } from '../../sdk-extensions/codecs';
+import type { Serializable } from '../../serialization/types';
+import {
+  MOCK_SOLANA_KEYRING_ACCOUNT_0,
+  MOCK_SOLANA_KEYRING_ACCOUNT_1,
+} from '../../test/mocks/solana-keyring-accounts';
+import type { AssetsService } from '../assets';
+import type { SolanaConnection } from '../connection';
+import { mockLogger } from '../mocks/logger';
+import { createMockConnection } from '../mocks/mockConnection';
+import { SendService } from './SendService';
+import {
+  SendErrorCodes,
+  type OnAddressInputRequest,
+  type OnAmountInputRequest,
+  type OnConfirmSendRequest,
+} from './types';
+
+// Mock dependencies
+jest.mock('../../sdk-extensions/codecs');
+
+// Mock crypto.randomUUID
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    randomUUID: jest.fn(() => 'test-uuid'),
+  },
+});
+
+describe('SendService', () => {
+  let sendService: SendService;
+  let mockConnection: SolanaConnection;
+  let mockKeyring: SolanaKeyring;
+  let mockCache: ICache<Serializable>;
+  let mockSendSolBuilder: SendSolBuilder;
+  let mockSendSplTokenBuilder: SendSplTokenBuilder;
+  let mockAssetsService: AssetsService;
+
+  const mockAccount: SolanaKeyringAccount = MOCK_SOLANA_KEYRING_ACCOUNT_0;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConnection = createMockConnection();
+    mockCache = new InMemoryCache(mockLogger);
+
+    jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+      getMinimumBalanceForRentExemption: jest.fn().mockReturnValue({
+        send: jest.fn().mockResolvedValue(lamports(1000000n)),
+      }),
+    } as any);
+
+    mockKeyring = {
+      getAccountOrThrow: jest.fn().mockResolvedValue(mockAccount),
+      submitRequest: jest.fn().mockResolvedValue({ success: true }),
+    } as unknown as SolanaKeyring;
+
+    mockSendSolBuilder = {
+      buildTransactionMessage: jest.fn().mockResolvedValue({} as any),
+      getComputeUnitLimit: jest.fn().mockReturnValue(200000),
+      getComputeUnitPriceMicroLamportsPerComputeUnit: jest
+        .fn()
+        .mockReturnValue(1000n),
+    } as unknown as SendSolBuilder;
+
+    mockSendSplTokenBuilder = {
+      buildTransactionMessage: jest.fn().mockResolvedValue({} as any),
+      getComputeUnitLimit: jest.fn().mockReturnValue(200000),
+      getComputeUnitPriceMicroLamportsPerComputeUnit: jest
+        .fn()
+        .mockReturnValue(1000n),
+    } as unknown as SendSplTokenBuilder;
+
+    mockAssetsService = {
+      findByAccount: jest.fn(),
+    } as unknown as AssetsService;
+
+    (
+      fromCompilableTransactionMessageToBase64String as jest.Mock
+    ).mockResolvedValue('base64-encoded-tx');
+
+    sendService = new SendService(
+      mockConnection,
+      mockKeyring,
+      mockLogger,
+      mockCache,
+      mockSendSolBuilder,
+      mockSendSplTokenBuilder,
+      mockAssetsService,
+    );
+  });
+
+  describe('confirmSend', () => {
+    const mockRequest: OnConfirmSendRequest = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: ClientRequestMethod.OnConfirmSend,
+      params: {
+        fromAccountId: mockAccount.id,
+        toAddress: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,
+        amount: '1.5',
+        assetId: Networks[Network.Mainnet].nativeToken.caip19Id,
+      },
+    };
+
+    it('confirms native SOL send transaction successfully', async () => {
+      const result = await sendService.confirmSend(mockRequest);
+
+      expect(mockKeyring.getAccountOrThrow).toHaveBeenCalledWith(
+        mockAccount.id,
+      );
+      expect(mockSendSolBuilder.buildTransactionMessage).toHaveBeenCalledWith({
+        from: mockAccount,
+        to: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,
+        amount: '1.5',
+        network: Network.Mainnet,
+      });
+      expect(mockKeyring.submitRequest).toHaveBeenCalledWith({
+        id: globalThis.crypto.randomUUID(),
+        scope: Network.Mainnet,
+        account: mockAccount.id,
+        origin: METAMASK_ORIGIN,
+        request: {
+          method: SolMethod.SignAndSendTransaction,
+          params: {
+            account: { address: mockAccount.address },
+            transaction: 'base64-encoded-tx',
+            scope: Network.Mainnet,
+          },
+        },
+      });
+      expect(result).toStrictEqual({ success: true });
+    });
+
+    it('confirms SPL token send transaction successfully', async () => {
+      const tokenRequest: OnConfirmSendRequest = {
+        ...mockRequest,
+        params: {
+          ...mockRequest.params,
+          assetId: KnownCaip19Id.UsdcMainnet,
+        },
+      };
+
+      const result = await sendService.confirmSend(tokenRequest);
+
+      expect(
+        mockSendSplTokenBuilder.buildTransactionMessage,
+      ).toHaveBeenCalledWith({
+        from: mockAccount,
+        to: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,
+        amount: '1.5',
+        network: Network.Mainnet,
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      });
+      expect(result).toStrictEqual({ success: true });
+    });
+
+    it('handles errors from keyring.getAccountOrThrow', async () => {
+      const error = new Error('Account not found');
+      jest.spyOn(mockKeyring, 'getAccountOrThrow').mockRejectedValue(error);
+
+      await expect(sendService.confirmSend(mockRequest)).rejects.toThrow(
+        'Account not found',
+      );
+    });
+
+    it('handles errors from builder.buildTransactionMessage', async () => {
+      const error = new Error('Failed to build transaction');
+      jest
+        .spyOn(mockSendSolBuilder, 'buildTransactionMessage')
+        .mockRejectedValue(error);
+
+      await expect(sendService.confirmSend(mockRequest)).rejects.toThrow(
+        'Failed to build transaction',
+      );
+    });
+
+    it('handles errors from keyring.submitRequest', async () => {
+      const error = new Error('Failed to submit request');
+      jest.spyOn(mockKeyring, 'submitRequest').mockRejectedValue(error);
+
+      await expect(sendService.confirmSend(mockRequest)).rejects.toThrow(
+        'Failed to submit request',
+      );
+    });
+  });
+
+  describe('onAddressInput', () => {
+    const mockRequest: OnAddressInputRequest = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: ClientRequestMethod.OnAddressInput,
+      params: { value: MOCK_SOLANA_KEYRING_ACCOUNT_1.address },
+    };
+
+    it('validates valid address successfully', async () => {
+      const result = await sendService.onAddressInput(mockRequest);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toStrictEqual([]);
+    });
+
+    it('rejects empty address', async () => {
+      const emptyRequest: OnAddressInputRequest = {
+        ...mockRequest,
+        params: { value: '' },
+      };
+
+      const result = await sendService.onAddressInput(emptyRequest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toStrictEqual([{ code: SendErrorCodes.Required }]);
+    });
+
+    it('rejects invalid address', async () => {
+      const invalidAddressRequest: OnAddressInputRequest = {
+        ...mockRequest,
+        params: { value: 'invalid-address' },
+      };
+
+      const result = await sendService.onAddressInput(invalidAddressRequest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toStrictEqual([{ code: SendErrorCodes.Invalid }]);
+    });
+
+    it('handles null/undefined address', async () => {
+      const nullRequest: OnAddressInputRequest = {
+        ...mockRequest,
+        params: { value: null as any },
+      };
+
+      const result = await sendService.onAddressInput(nullRequest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toStrictEqual([{ code: SendErrorCodes.Invalid }]);
+    });
+  });
+
+  describe('onAmountInput', () => {
+    const mockRequest: OnAmountInputRequest = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: ClientRequestMethod.OnAmountInput,
+      params: {
+        value: '1.5',
+        accountId: mockAccount.id,
+        assetId: Networks[Network.Mainnet].nativeToken.caip19Id,
+      },
+    };
+
+    const mockAssetBalances: AssetEntity[] = [
+      {
+        assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+        uiAmount: '10.0',
+        keyringAccountId: mockAccount.id,
+        network: Network.Mainnet,
+        address: mockAccount.address,
+        symbol: Networks[Network.Mainnet].nativeToken.symbol,
+        decimals: Networks[Network.Mainnet].nativeToken.decimals,
+        rawAmount: '10000000000',
+      },
+    ];
+
+    beforeEach(() => {
+      jest
+        .spyOn(mockAssetsService, 'findByAccount')
+        .mockResolvedValue(mockAssetBalances);
+
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getMinimumBalanceForRentExemption: jest.fn().mockReturnValue({
+          send: jest.fn().mockResolvedValue(lamports(1000000n)),
+        }),
+      } as any);
+    });
+
+    it('validates valid native SOL amount successfully', async () => {
+      const result = await sendService.onAmountInput(mockRequest);
+
+      expect(result).toStrictEqual({
+        valid: true,
+        errors: [],
+      });
+    });
+
+    it('rejects empty amount', async () => {
+      const emptyRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: { ...mockRequest.params, value: '' },
+      };
+
+      const result = await sendService.onAmountInput(emptyRequest);
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.Required }],
+      });
+    });
+
+    it('rejects when asset balance not found', async () => {
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([]);
+
+      await expect(sendService.onAmountInput(mockRequest)).rejects.toThrow(
+        `Balance not found for asset ${mockRequest.params.assetId} and account ${mockAccount.id}`,
+      );
+    });
+
+    it('rejects when native SOL balance is insufficient for rent exemption', async () => {
+      const lowBalanceRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: { ...mockRequest.params, value: '0.000001' },
+      };
+
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([
+        {
+          assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+          uiAmount: '0.00001',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          address: mockAccount.address,
+          symbol: Networks[Network.Mainnet].nativeToken.symbol,
+          decimals: Networks[Network.Mainnet].nativeToken.decimals,
+          rawAmount: '999999999999999999',
+        },
+      ]);
+
+      const result = await sendService.onAmountInput(lowBalanceRequest);
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalanceToCoverFee }],
+      });
+    });
+
+    it('rejects when SOL balance is insufficient to cover fee and rent', async () => {
+      const insufficientBalanceRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: { ...mockRequest.params, value: '9.999999999' },
+      };
+
+      const result = await sendService.onAmountInput(
+        insufficientBalanceRequest,
+      );
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalanceToCoverFee }],
+      });
+    });
+
+    it('rejects when value is greater than asset balance', async () => {
+      const zeroBalanceRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: {
+          ...mockRequest.params,
+          assetId: KnownCaip19Id.UsdcMainnet,
+          value: '0.1',
+        },
+      };
+
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([
+        {
+          assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+          uiAmount: '0.1',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          address: mockAccount.address,
+          symbol: Networks[Network.Mainnet].nativeToken.symbol,
+          decimals: Networks[Network.Mainnet].nativeToken.decimals,
+          rawAmount: '10000000000',
+        },
+        {
+          assetType: KnownCaip19Id.UsdcMainnet,
+          uiAmount: '0.001',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          mint: 'token-address-123',
+          pubkey: 'token-address-123',
+          symbol: 'USDC',
+          decimals: 6,
+          rawAmount: '1000000',
+        },
+      ]);
+
+      const result = await sendService.onAmountInput(zeroBalanceRequest);
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalance }],
+      });
+    });
+
+    it('rejects when native SOL balance is zero', async () => {
+      const zeroSolRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: { ...mockRequest.params, value: '0.1' },
+      };
+
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([
+        {
+          assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+          uiAmount: '0',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          address: mockAccount.address,
+          symbol: Networks[Network.Mainnet].nativeToken.symbol,
+          decimals: Networks[Network.Mainnet].nativeToken.decimals,
+          rawAmount: '0',
+        },
+      ]);
+
+      const result = await sendService.onAmountInput(zeroSolRequest);
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalance }],
+      });
+    });
+
+    it('validates SPL token amount successfully', async () => {
+      const tokenRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: {
+          ...mockRequest.params,
+          assetId: KnownCaip19Id.UsdcMainnet,
+        },
+      };
+
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([
+        {
+          assetType: KnownCaip19Id.UsdcMainnet,
+          uiAmount: '100.0',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          mint: 'token-address-123',
+          pubkey: 'token-address-123',
+          symbol: 'USDC',
+          decimals: 6,
+          rawAmount: '100000000000',
+        },
+        {
+          assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+          uiAmount: '1.0',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          address: mockAccount.address,
+          symbol: Networks[Network.Mainnet].nativeToken.symbol,
+          decimals: Networks[Network.Mainnet].nativeToken.decimals,
+          rawAmount: '10000000000',
+        },
+      ]);
+
+      const result = await sendService.onAmountInput(tokenRequest);
+
+      expect(result).toStrictEqual({
+        valid: true,
+        errors: [],
+      });
+    });
+
+    it('rejects SPL token when SOL balance is insufficient for fee and rent', async () => {
+      const tokenRequest: OnAmountInputRequest = {
+        ...mockRequest,
+        params: {
+          ...mockRequest.params,
+          assetId: KnownCaip19Id.UsdcMainnet,
+        },
+      };
+
+      jest.spyOn(mockAssetsService, 'findByAccount').mockResolvedValue([
+        {
+          assetType: KnownCaip19Id.UsdcMainnet,
+          uiAmount: '100.0',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          mint: 'token-address-123',
+          pubkey: 'token-address-123',
+          symbol: 'USDC',
+          decimals: 6,
+          rawAmount: '100000000000',
+        },
+        {
+          assetType: Networks[Network.Mainnet].nativeToken.caip19Id,
+          uiAmount: '0.0001',
+          keyringAccountId: mockAccount.id,
+          network: Network.Mainnet,
+          address: mockAccount.address,
+          symbol: Networks[Network.Mainnet].nativeToken.symbol,
+          decimals: Networks[Network.Mainnet].nativeToken.decimals,
+          rawAmount: '10000000000',
+        },
+      ]);
+
+      const result = await sendService.onAmountInput(tokenRequest);
+
+      expect(result).toStrictEqual({
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalanceToCoverFee }],
+      });
+    });
+
+    it('handles errors if account is not found', async () => {
+      const error = new Error('Account not found');
+      jest.spyOn(mockKeyring, 'getAccountOrThrow').mockRejectedValue(error);
+
+      await expect(sendService.onAmountInput(mockRequest)).rejects.toThrow(
+        'Account not found',
+      );
+    });
+
+    it('handles errors if balances are not found', async () => {
+      const error = new Error('Failed to fetch balances');
+      jest.spyOn(mockAssetsService, 'findByAccount').mockRejectedValue(error);
+
+      await expect(sendService.onAmountInput(mockRequest)).rejects.toThrow(
+        'Failed to fetch balances',
+      );
+    });
+
+    it('handles errors if connection fails', async () => {
+      const error = new Error('RPC connection failed');
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getMinimumBalanceForRentExemption: jest.fn().mockReturnValue({
+          send: jest.fn().mockRejectedValue(error),
+        }),
+      } as any);
+
+      await expect(sendService.onAmountInput(mockRequest)).rejects.toThrow(
+        'RPC connection failed',
+      );
+    });
+  });
+});

--- a/packages/snap/src/core/services/send/SendService.ts
+++ b/packages/snap/src/core/services/send/SendService.ts
@@ -1,0 +1,310 @@
+import type { KeyringRequest } from '@metamask/keyring-api';
+import { SolMethod } from '@metamask/keyring-api';
+import type { Json } from '@metamask/snaps-sdk';
+import { Duration, parseCaipAssetType } from '@metamask/utils';
+import { address as asAddress } from '@solana/kit';
+import { BigNumber } from 'bignumber.js';
+
+import { SendFeeCalculator } from '../../../features/send/transactions/SendFeeCalculator';
+import type { SendSolBuilder } from '../../../features/send/transactions/SendSolBuilder';
+import type { SendSplTokenBuilder } from '../../../features/send/transactions/SendSplTokenBuilder';
+import type { ICache } from '../../caching/ICache';
+import { useCache } from '../../caching/useCache';
+import { METAMASK_ORIGIN, Networks } from '../../constants/solana';
+import type { Network } from '../../constants/solana';
+import type { SolanaKeyring } from '../../handlers/onKeyringRequest/Keyring';
+import { fromCompilableTransactionMessageToBase64String } from '../../sdk-extensions/codecs';
+import type { Serializable } from '../../serialization/types';
+import { solToLamports } from '../../utils/conversion';
+import { createPrefixedLogger, type ILogger } from '../../utils/logger';
+import type { AssetsService } from '../assets';
+import type { SolanaConnection } from '../connection';
+import {
+  SendErrorCodes,
+  type OnAddressInputRequest,
+  type OnAmountInputRequest,
+  type OnConfirmSendRequest,
+  type ValidationResponse,
+} from './types';
+
+export class SendService {
+  readonly #connection: SolanaConnection;
+
+  readonly #keyring: SolanaKeyring;
+
+  readonly #logger: ILogger;
+
+  readonly #cache: ICache<Serializable>;
+
+  readonly #sendSolBuilder: SendSolBuilder;
+
+  readonly #sendSplTokenBuilder: SendSplTokenBuilder;
+
+  readonly #assetsService: AssetsService;
+
+  readonly #cacheTtlsMilliseconds = {
+    minimumBalanceForRentExemption: 5 * Duration.Minute,
+  };
+
+  constructor(
+    connection: SolanaConnection,
+    keyring: SolanaKeyring,
+    logger: ILogger,
+    cache: ICache<Serializable>,
+    sendSolBuilder: SendSolBuilder,
+    sendSplTokenBuilder: SendSplTokenBuilder,
+    assetsService: AssetsService,
+  ) {
+    this.#connection = connection;
+    this.#keyring = keyring;
+    this.#cache = cache;
+    this.#logger = createPrefixedLogger(logger, '[📬 SendService]');
+    this.#sendSolBuilder = sendSolBuilder;
+    this.#sendSplTokenBuilder = sendSplTokenBuilder;
+    this.#assetsService = assetsService;
+  }
+
+  async #getCachedMinimumBalanceForRentExemption(
+    scope: Network,
+  ): Promise<BigNumber> {
+    const minimumBalanceForRentExemption = useCache<[Network], BigNumber>(
+      async (_scope: Network) =>
+        this.#connection
+          .getRpc(scope)
+          .getMinimumBalanceForRentExemption(BigInt(0))
+          .send()
+          .then((response) => BigNumber(response.toString())),
+      this.#cache,
+      {
+        functionName: 'SendService:getMinimumBalanceForRentExemption',
+        ttlMilliseconds:
+          this.#cacheTtlsMilliseconds.minimumBalanceForRentExemption,
+        generateCacheKey: (functionName, args) => {
+          const [_scope] = args;
+          return `${functionName}:${_scope}`;
+        },
+      },
+    );
+
+    return minimumBalanceForRentExemption(scope);
+  }
+
+  /**
+   * Handles the confirmation of a send transaction.
+   *
+   * @param request - The JSON-RPC request containing the parameters.
+   * @returns The response to the JSON-RPC request.
+   * @throws {InvalidParamsError} If the params are invalid.
+   */
+  async confirmSend(request: OnConfirmSendRequest): Promise<Json> {
+    const { fromAccountId, toAddress, amount, assetId } = request.params;
+
+    const account = await this.#keyring.getAccountOrThrow(fromAccountId);
+
+    const { chainId, assetReference } = parseCaipAssetType(assetId);
+
+    const scope = chainId as Network;
+
+    const isNativeSend = assetId === Networks[scope].nativeToken.caip19Id;
+
+    const builder = isNativeSend
+      ? this.#sendSolBuilder
+      : this.#sendSplTokenBuilder;
+
+    this.#logger.log('Confirming send transaction', {
+      fromAccountId,
+      toAddress,
+      amount,
+      assetId,
+    });
+
+    const params = {
+      from: account,
+      to: asAddress(toAddress),
+      amount,
+      network: scope,
+      ...(isNativeSend ? {} : { mint: asAddress(assetReference) }),
+    };
+
+    const transactionMessage = await builder.buildTransactionMessage(params);
+
+    const base64EncodedTransactionMessage =
+      await fromCompilableTransactionMessageToBase64String(transactionMessage);
+
+    const keyringRequest: KeyringRequest = {
+      id: globalThis.crypto.randomUUID(),
+      scope,
+      account: fromAccountId,
+      origin: METAMASK_ORIGIN,
+      request: {
+        method: SolMethod.SignAndSendTransaction,
+        params: {
+          account: {
+            address: account.address,
+          },
+          transaction: base64EncodedTransactionMessage,
+          scope,
+        },
+      },
+    };
+
+    this.#logger.log('Submitting keyring request', keyringRequest);
+
+    return this.#keyring.submitRequest(keyringRequest);
+  }
+
+  /**
+   * Handles the input of an address.
+   *
+   * @param request - The JSON-RPC request containing the parameters.
+   * @returns The response to the JSON-RPC request.
+   * @throws {InvalidParamsError} If the params are invalid.
+   */
+  async onAddressInput(
+    request: OnAddressInputRequest,
+  ): Promise<ValidationResponse> {
+    const {
+      params: { value },
+    } = request;
+
+    if (value === '') {
+      return {
+        valid: false,
+        errors: [{ code: SendErrorCodes.Required }],
+      };
+    }
+
+    try {
+      asAddress(value);
+
+      return {
+        valid: true,
+        errors: [],
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        errors: [{ code: SendErrorCodes.Invalid }],
+      };
+    }
+  }
+
+  /**
+   * Handles the input of an amount.
+   *
+   * Covers the following errors:
+   * - Required: If the value is empty.
+   * - InsufficientSolToCoverFee: If the value is less than the minimum balance for rent exemption.
+   * - InsufficientBalance: If the value is greater than the balance.
+   *
+   * @param request - The JSON-RPC request containing the parameters.
+   * @returns The response to the JSON-RPC request.
+   */
+  async onAmountInput(
+    request: OnAmountInputRequest,
+  ): Promise<ValidationResponse> {
+    const {
+      params: { value, accountId, assetId },
+    } = request;
+
+    const account = await this.#keyring.getAccountOrThrow(accountId);
+
+    const { chainId } = parseCaipAssetType(assetId);
+
+    const scope = chainId as Network;
+
+    const nativeAssetType = Networks[scope].nativeToken.caip19Id;
+
+    const isNativeToken = assetId === nativeAssetType;
+
+    const accountBalances = await this.#assetsService.findByAccount(account);
+
+    const assetEntry = accountBalances.find(
+      (asset) => asset.assetType === assetId,
+    );
+
+    const nativeAsset = accountBalances.find(
+      (asset) => asset.assetType === nativeAssetType,
+    );
+
+    if (!assetEntry) {
+      throw new Error(
+        `Balance not found for asset ${assetId} and account ${accountId}`,
+      );
+    }
+
+    // 1. value is required
+    if (value === '') {
+      return {
+        valid: false,
+        errors: [{ code: SendErrorCodes.Required }],
+      };
+    }
+
+    const assetBalanceLamports = solToLamports(assetEntry.uiAmount ?? '0');
+    const nativeBalanceLamports = solToLamports(nativeAsset?.uiAmount ?? '0');
+    const valueLamports = solToLamports(value);
+
+    const minimumBalanceForRentExemptionLamports =
+      await this.#getCachedMinimumBalanceForRentExemption(scope);
+
+    const builder = isNativeToken
+      ? this.#sendSolBuilder
+      : this.#sendSplTokenBuilder;
+
+    const sendFeeCalculator = new SendFeeCalculator(builder);
+    const feeInLamports = sendFeeCalculator.getFee();
+    const feeEstimatedInLamports = BigNumber(feeInLamports.toString());
+
+    // If you have 0 SOL, you can't pay for the fee, it's invalid
+    if (nativeBalanceLamports.isZero()) {
+      return {
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalance }],
+      };
+    }
+
+    // If the native balance is lower than the minimum balance for rent exemption, it's invalid
+    const nativeBalanceLowerThanMinimum = nativeBalanceLamports.lt(
+      minimumBalanceForRentExemptionLamports,
+    );
+
+    if (nativeBalanceLowerThanMinimum) {
+      return {
+        valid: false,
+        errors: [{ code: SendErrorCodes.InsufficientBalanceToCoverFee }],
+      };
+    }
+
+    if (isNativeToken) {
+      // If the (amount + fee + minimum balance for rent exemption) is greater than the native balance, it's invalid
+      const isAmountPlusFeePlusRentExemptionGreaterThanBalance = valueLamports
+        .plus(feeEstimatedInLamports)
+        .plus(minimumBalanceForRentExemptionLamports)
+        .gt(nativeBalanceLamports);
+
+      if (isAmountPlusFeePlusRentExemptionGreaterThanBalance) {
+        return {
+          valid: false,
+          errors: [{ code: SendErrorCodes.InsufficientBalanceToCoverFee }],
+        };
+      }
+    } else {
+      // If the amount is greater than the asset balance, it's invalid
+      const isAmountGreaterThanAssetBalance =
+        valueLamports.gt(assetBalanceLamports);
+
+      if (isAmountGreaterThanAssetBalance) {
+        return {
+          valid: false,
+          errors: [{ code: SendErrorCodes.InsufficientBalance }],
+        };
+      }
+    }
+
+    return {
+      valid: true,
+      errors: [],
+    };
+  }
+}

--- a/packages/snap/src/core/services/send/types.ts
+++ b/packages/snap/src/core/services/send/types.ts
@@ -1,0 +1,23 @@
+import type { Infer } from '@metamask/superstruct';
+
+import type {
+  OnAddressInputRequestStruct,
+  OnAmountInputRequestStruct,
+  OnConfirmSendRequestStruct,
+  ValidationResponseStruct,
+} from '../../handlers/onClientRequest/validation';
+
+export type OnConfirmSendRequest = Infer<typeof OnConfirmSendRequestStruct>;
+
+export type OnAddressInputRequest = Infer<typeof OnAddressInputRequestStruct>;
+
+export type OnAmountInputRequest = Infer<typeof OnAmountInputRequestStruct>;
+
+export type ValidationResponse = Infer<typeof ValidationResponseStruct>;
+
+export enum SendErrorCodes {
+  Required = 'Required',
+  Invalid = 'Invalid',
+  InsufficientBalanceToCoverFee = 'InsufficientBalanceToCoverFee',
+  InsufficientBalance = 'InsufficientBalance',
+}

--- a/packages/snap/src/core/services/transaction-scan/TransactionScan.ts
+++ b/packages/snap/src/core/services/transaction-scan/TransactionScan.ts
@@ -2,7 +2,11 @@
 import type { SolanaKeyringAccount } from '../../../entities';
 import type { SecurityAlertsApiClient } from '../../clients/security-alerts-api/SecurityAlertsApiClient';
 import type { SecurityAlertSimulationValidationResponse } from '../../clients/security-alerts-api/types';
-import type { Network } from '../../constants/solana';
+import {
+  METAMASK_ORIGIN,
+  METAMASK_ORIGIN_URL,
+  type Network,
+} from '../../constants/solana';
 import type { ILogger } from '../../utils/logger';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { TokenMetadataService } from '../token-metadata/TokenMetadata';
@@ -67,7 +71,7 @@ export class TransactionScanService {
         accountAddress,
         transactions: [transaction],
         scope,
-        origin,
+        origin: origin === METAMASK_ORIGIN ? METAMASK_ORIGIN_URL : origin,
         options,
       });
 

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -27,14 +27,6 @@ import { getSolanaExplorerUrl } from '../../utils/getSolanaExplorerUrl';
 import type { ILogger } from '../../utils/logger';
 import logger from '../../utils/logger';
 import {
-  sanitizeDomain,
-  sanitizeSolanaAddress,
-  sanitizeUri,
-  sanitizeTimestamp,
-  sanitizeForSignInMessage,
-  sanitizeResources,
-} from '../../utils/sanitize';
-import {
   Base58Struct,
   Base64Struct,
   NetworkStruct,

--- a/packages/snap/src/core/utils/parseOrigin.test.ts
+++ b/packages/snap/src/core/utils/parseOrigin.test.ts
@@ -1,0 +1,106 @@
+import { METAMASK_ORIGIN } from '../constants/solana';
+import { parseOrigin } from './parseOrigin';
+
+describe('parseOrigin', () => {
+  describe('when origin is MetaMask', () => {
+    it('returns "MetaMask" for metamask origin', () => {
+      expect(parseOrigin(METAMASK_ORIGIN)).toBe('MetaMask');
+    });
+
+    it('returns "MetaMask" for exact string match', () => {
+      expect(parseOrigin('metamask')).toBe('MetaMask');
+    });
+  });
+
+  describe('when origin is a valid URL', () => {
+    it('returns hostname for HTTP URLs', () => {
+      expect(parseOrigin('http://example.com')).toBe('example.com');
+      expect(parseOrigin('http://www.example.com')).toBe('www.example.com');
+      expect(parseOrigin('http://sub.example.com')).toBe('sub.example.com');
+    });
+
+    it('returns hostname for HTTPS URLs', () => {
+      expect(parseOrigin('https://example.com')).toBe('example.com');
+      expect(parseOrigin('https://www.example.com')).toBe('www.example.com');
+      expect(parseOrigin('https://sub.example.com')).toBe('sub.example.com');
+    });
+
+    it('returns hostname for URLs with paths', () => {
+      expect(parseOrigin('https://example.com/path')).toBe('example.com');
+      expect(parseOrigin('https://example.com/path/to/resource')).toBe(
+        'example.com',
+      );
+      expect(parseOrigin('https://example.com/path?query=value')).toBe(
+        'example.com',
+      );
+    });
+
+    it('returns hostname for URLs with query parameters', () => {
+      expect(parseOrigin('https://example.com?param=value')).toBe(
+        'example.com',
+      );
+      expect(
+        parseOrigin('https://example.com/path?param1=value1&param2=value2'),
+      ).toBe('example.com');
+    });
+
+    it('returns hostname for URLs with fragments', () => {
+      expect(parseOrigin('https://example.com#section')).toBe('example.com');
+      expect(parseOrigin('https://example.com/path#section')).toBe(
+        'example.com',
+      );
+    });
+
+    it('returns hostname for URLs with ports', () => {
+      expect(parseOrigin('https://example.com:8080')).toBe('example.com');
+      expect(parseOrigin('http://localhost:3000')).toBe('localhost');
+    });
+
+    it('returns hostname for localhost URLs', () => {
+      expect(parseOrigin('http://localhost')).toBe('localhost');
+      expect(parseOrigin('http://localhost:3000')).toBe('localhost');
+      expect(parseOrigin('https://localhost')).toBe('localhost');
+    });
+
+    it('returns hostname for IP addresses', () => {
+      expect(parseOrigin('http://192.168.1.1')).toBe('192.168.1.1');
+      expect(parseOrigin('https://127.0.0.1')).toBe('127.0.0.1');
+      expect(parseOrigin('http://192.168.1.1:8080')).toBe('192.168.1.1');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('throws an error for URLs without protocol', () => {
+      expect(() => parseOrigin('//example.com')).toThrow('Invalid URL');
+      expect(() => parseOrigin('//www.example.com')).toThrow('Invalid URL');
+    });
+
+    it('handles URLs with custom protocols', () => {
+      expect(parseOrigin('ftp://example.com')).toBe('example.com');
+      expect(parseOrigin('ws://example.com')).toBe('example.com');
+      expect(parseOrigin('wss://example.com')).toBe('example.com');
+    });
+
+    it('handles complex subdomains', () => {
+      expect(parseOrigin('https://api.v1.example.com')).toBe(
+        'api.v1.example.com',
+      );
+      expect(parseOrigin('https://dev.staging.example.com')).toBe(
+        'dev.staging.example.com',
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws error for invalid URLs', () => {
+      expect(() => parseOrigin('not-a-url')).toThrow('Invalid URL');
+      expect(() => parseOrigin('http://')).toThrow('Invalid URL');
+      expect(() => parseOrigin('https://')).toThrow('Invalid URL');
+      expect(() => parseOrigin('')).toThrow('Invalid URL');
+    });
+
+    it('throws error for malformed URLs', () => {
+      expect(() => parseOrigin('http://:8080')).toThrow('Invalid URL');
+    });
+  });
+});

--- a/packages/snap/src/core/utils/parseOrigin.ts
+++ b/packages/snap/src/core/utils/parseOrigin.ts
@@ -1,0 +1,19 @@
+import { METAMASK_ORIGIN } from '../constants/solana';
+
+/**
+ * Parses the origin from a string.
+ *
+ * @param origin - The origin to parse.
+ * @returns The parsed origin.
+ */
+export function parseOrigin(origin: string) {
+  if (origin === METAMASK_ORIGIN) {
+    return 'MetaMask';
+  }
+
+  try {
+    return new URL(origin).hostname;
+  } catch (error) {
+    throw new Error('Invalid URL');
+  }
+}

--- a/packages/snap/src/core/validation/structs.ts
+++ b/packages/snap/src/core/validation/structs.ts
@@ -13,6 +13,7 @@ import {
   refine,
   string,
 } from '@metamask/superstruct';
+import { address } from '@solana/kit';
 
 import { Network } from '../constants/solana';
 
@@ -306,4 +307,20 @@ export const DerivationPathStruct = pattern(string(), DERIVATION_PATH_REGEX);
 export const Iso8601Struct = pattern(
   string(),
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/u,
+);
+
+export const SolanaAddressStruct: Struct<string, null> = define(
+  'SolanaAddress',
+  (value) => {
+    if (typeof value !== 'string') {
+      return `Expected a string, but received: ${typeof value}`;
+    }
+
+    try {
+      address(value);
+      return true;
+    } catch (error) {
+      return 'Invalid Solana address';
+    }
+  },
 );

--- a/packages/snap/src/features/confirmation/components/TransactionDetails/TransactionDetails.tsx
+++ b/packages/snap/src/features/confirmation/components/TransactionDetails/TransactionDetails.tsx
@@ -17,6 +17,7 @@ import { addressToCaip10 } from '../../../../core/utils/addressToCaip10';
 import { formatCrypto } from '../../../../core/utils/formatCrypto';
 import { formatFiat } from '../../../../core/utils/formatFiat';
 import { i18n } from '../../../../core/utils/i18n';
+import { parseOrigin } from '../../../../core/utils/parseOrigin';
 import { tokenToFiat } from '../../../../core/utils/tokenToFiat';
 
 type TransactionDetailsProps = {
@@ -42,7 +43,7 @@ export const TransactionDetails: SnapComponent<TransactionDetailsProps> = ({
 }) => {
   const { currency, locale } = preferences;
   const translate = i18n(locale);
-  const originHostname = origin ? new URL(origin).hostname : null;
+  const originHostname = origin ? parseOrigin(origin) : null;
 
   const pricesFetching = fetchingPricesStatus === 'fetching';
   const pricesError = fetchingPricesStatus === 'error';

--- a/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmSignIn/ConfirmSignIn.tsx
@@ -18,6 +18,7 @@ import { SOL_IMAGE_SVG } from '../../../../core/test/mocks/solana-image-svg';
 import type { Preferences } from '../../../../core/types/snap';
 import { addressToCaip10 } from '../../../../core/utils/addressToCaip10';
 import { i18n } from '../../../../core/utils/i18n';
+import { parseOrigin } from '../../../../core/utils/parseOrigin';
 import type { SolanaKeyringAccount } from '../../../../entities';
 import { BasicNullableField } from '../../components/BasicNullableField/BasicNullableField';
 import { EstimatedChanges } from '../../components/EstimatedChanges/EstimatedChanges';
@@ -54,7 +55,7 @@ export const ConfirmSignIn: SnapComponent<ConfirmSignInProps> = ({
   networkImage,
 }) => {
   const translate = i18n(preferences.locale);
-  const originHostname = origin ? new URL(origin).hostname : null;
+  const originHostname = origin ? parseOrigin(origin) : null;
 
   const {
     domain,

--- a/packages/snap/src/features/confirmation/views/ConfirmSignMessage/ConfirmSignMessage.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmSignMessage/ConfirmSignMessage.tsx
@@ -19,6 +19,7 @@ import { SOL_IMAGE_SVG } from '../../../../core/test/mocks/solana-image-svg';
 import { addressToCaip10 } from '../../../../core/utils/addressToCaip10';
 import type { Locale } from '../../../../core/utils/i18n';
 import { i18n } from '../../../../core/utils/i18n';
+import { parseOrigin } from '../../../../core/utils/parseOrigin';
 import type { SolanaKeyringAccount } from '../../../../entities';
 import { ConfirmSignMessageFormNames } from './events';
 
@@ -41,7 +42,7 @@ export const ConfirmSignMessage: SnapComponent<ConfirmSignMessageProps> = ({
 }) => {
   const translate = i18n(locale);
   const { address } = account;
-  const originHostname = origin ? new URL(origin).hostname : null;
+  const originHostname = origin ? parseOrigin(origin) : null;
   const addressCaip10 = addressToCaip10(scope, address);
 
   return (

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -30,6 +30,7 @@ import { SolanaConnection } from './core/services/connection/SolanaConnection';
 import { TransactionHelper } from './core/services/execution/TransactionHelper';
 import { NameResolutionService } from './core/services/name-resolution/NameResolutionService';
 import { NftService } from './core/services/nft/NftService';
+import { SendService } from './core/services/send/SendService';
 import type { IStateManager } from './core/services/state/IStateManager';
 import type { UnencryptedStateValue } from './core/services/state/State';
 import { DEFAULT_UNENCRYPTED_STATE, State } from './core/services/state/State';
@@ -215,10 +216,21 @@ const keyring = new SolanaKeyring({
 
 const nftService = new NftService(connection, logger);
 
+const sendService = new SendService(
+  connection,
+  keyring,
+  logger,
+  inMemoryCache,
+  sendSolBuilder,
+  sendSplTokenBuilder,
+  assetsService,
+);
+
 const clientRequestHandler = new ClientRequestHandler(
   keyring,
   walletService,
   logger,
+  sendService,
 );
 
 const snapContext: SnapExecutionContext = {


### PR DESCRIPTION
This pull request adds support for new client request methods related to sending Solana transactions, including request validation and service integration. It introduces three new methods—`onConfirmSend`, `onAddressInput`, and `onAmountInput`—with corresponding request/response validation and handler logic. The tests are significantly expanded to cover these new flows, and related types and constants are updated.

**New client request methods and handlers:**

- Added support for `onConfirmSend`, `onAddressInput`, and `onAmountInput` methods in the `ClientRequestHandler`, with dedicated private handler methods for each. These handlers validate requests, call the appropriate `SendService` methods, and validate responses as needed. 

**Validation and types:**

- Introduced comprehensive request and response validation structs for the new client request methods in `validation.ts`, including a `ValidationResponseStruct` and type.

**Testing improvements:**

- Expanded `ClientRequestHandler.test.ts` to cover all new request methods, including cases for valid requests, error propagation, and invalid parameters. Added a mock `SendService` and improved test clarity. 