### PR TITLE
refactor: swap/bridge methods

### DIFF
--- a/packages/snap/openrpc.json
+++ b/packages/snap/openrpc.json
@@ -21,7 +21,7 @@
     {
       "name": "signAndSendTransactionWithoutConfirmation",
       "summary": "Sign and send a transaction without showing a confirmation dialog",
-      "description": "Allows the client (MetaMask) to request the snap to sign and send a Solana transaction without showing a confirmation dialog to the user. This method validates the request parameters, finds the account in the keyring, signs the transaction, and sends it to the Solana network.",
+      "description": "Allows the client (MetaMask) to request the snap to sign and send a Solana transaction without showing a confirmation dialog to the user. This method validates the request parameters, finds the account in the keyring, signs the transaction, and sends it to the Solana network. **Note: This method is deprecated and will be removed in the next major version.**",
       "paramStructure": "by-name",
       "params": [
         {
@@ -102,7 +102,96 @@
       ]
     },
     {
-      "name": "onConfirmSend",
+      "name": "signAndSendTransaction",
+      "summary": "Sign and send a transaction",
+      "description": "Allows the client (MetaMask) to request the snap to sign and send a Solana transaction. This method validates the request parameters, finds the account in the keyring, signs the transaction, and sends it to the Solana network.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "accountId",
+          "summary": "The UUID of the account to use for signing the transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Uuid"
+          }
+        },
+        {
+          "name": "transaction",
+          "summary": "The base64-encoded transaction to sign and send",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Base64String"
+          }
+        },
+        {
+          "name": "scope",
+          "summary": "The Solana network to send the transaction to",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Network"
+          }
+        },
+        {
+          "name": "options",
+          "summary": "Optional transaction options",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/TransactionOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "SignAndSendTransactionResult",
+        "summary": "The result of signing and sending a transaction",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transactionId": {
+              "$ref": "#/components/schemas/Base58String",
+              "description": "The transaction signature returned after successful execution on Solana"
+            }
+          },
+          "required": ["transactionId"],
+          "additionalProperties": false
+        }
+      },
+      "examples": [
+        {
+          "name": "signAndSendTransactionExample",
+          "description": "Example of signing and sending a simple SOL transfer transaction",
+          "params": [
+            {
+              "name": "accountId",
+              "value": "c747acb9-1b2b-4352-b9da-3d658fcc3cc7"
+            },
+            {
+              "name": "transaction",
+              "value": "gAEAAgSZsAKPnZ6vMobike0KV4I/ucjxTM1cFYhLnVhPWfjfdN2zrulHQhiUvVcoUaPML7MFkgDu9PV2PudQFNTACzusAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAHWszLmyDo8VIk2P/sVmDUn34YE2+73fS1kNLCNojDEqAwMABQIsAQAAAwAJA+gDAAAAAAAAAgIAAQwCAAAAQEIPAAAAAAAA"
+            },
+            {
+              "name": "scope",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            },
+            {
+              "name": "options",
+              "value": {
+                "commitment": "confirmed",
+                "skipPreflight": false,
+                "maxRetries": 3
+              }
+            }
+          ],
+          "result": {
+            "name": "signAndSendTransactionResult",
+            "value": {
+              "transactionId": "2jy9nsDuajiPgRRijs7Ku4JVvTFQ224Nhoc58fe72tRoy384JAF6zVWFV2SwTt9XXykxes6LkU6VLokn6wAXTocQ"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "confirmSend",
       "summary": "Confirm and execute a send transaction",
       "description": "Confirms and executes a send transaction with the specified parameters. This method validates the request parameters and submits the transaction to the Solana network.",
       "paramStructure": "by-name",
@@ -141,7 +230,7 @@
         }
       ],
       "result": {
-        "name": "OnConfirmSendResult",
+        "name": "ConfirmSendResult",
         "summary": "The result of confirming and executing the send transaction",
         "schema": {
           "$ref": "#/components/schemas/SignAndSendTransactionResult"
@@ -149,7 +238,7 @@
       },
       "examples": [
         {
-          "name": "onConfirmSendExample",
+          "name": "confirmSendExample",
           "description": "Example of confirming a SOL send transaction",
           "params": [
             {
@@ -170,10 +259,99 @@
             }
           ],
           "result": {
-            "name": "onConfirmSendResult",
+            "name": "confirmSendResult",
             "value": {
               "signature": "2jy9nsDuajiPgRRijs7Ku4JVvTFQ224Nhoc58fe72tRoy384JAF6zVWFV2SwTt9XXykxes6LkU6VLokn6wAXTocQ"
             }
+          }
+        }
+      ]
+    },
+    {
+      "name": "computeFee",
+      "summary": "Compute the fee for a transaction",
+      "description": "Computes and returns the fee for a given transaction. This method helps users understand the cost of their transaction before execution.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction",
+          "summary": "The base64-encoded transaction to calculate fees for",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "scope",
+          "summary": "The Solana network scope",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Network"
+          }
+        }
+      ],
+      "result": {
+        "name": "ComputeFeeResult",
+        "summary": "The computed fee information",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["base"]
+              },
+              "asset": {
+                "type": "object",
+                "properties": {
+                  "unit": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "string"
+                  },
+                  "fungible": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["unit", "type", "amount", "fungible"]
+              }
+            },
+            "required": ["type", "asset"]
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "computeFeeExample",
+          "description": "Example of computing the fee for a transaction",
+          "params": [
+            {
+              "name": "transaction",
+              "value": "gAEAAgSZsAKPnZ6vMobike0KV4I/ucjxTM1cFYhLnVhPWfjfdN2zrulHQhiUvVcoUaPML7MFkgDu9PV2PudQFNTACzusAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAHWszLmyDo8VIk2P/sVmDUn34YE2+73fS1kNLCNojDEqAwMABQIsAQAAAwAJA+gDAAAAAAAAAgIAAQwCAAAAQEIPAAAAAAAA"
+            },
+            {
+              "name": "scope",
+              "value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            }
+          ],
+          "result": {
+            "name": "computeFeeResult",
+            "value": [
+              {
+                "type": "base",
+                "asset": {
+                  "unit": "SOL",
+                  "type": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",
+                  "amount": "0.000015",
+                  "fungible": true
+                }
+              }
+            ]
           }
         }
       ]
@@ -355,7 +533,7 @@
     {
       "name": "getFeeForTransaction",
       "summary": "Get the fee for a transaction",
-      "description": "Calculates and returns the fee for a given transaction in lamports. This method helps users understand the cost of their transaction before execution.",
+      "description": "Calculates and returns the fee for a given transaction in lamports. This method helps users understand the cost of their transaction before execution. **Note: This method is deprecated and will be removed in the next major version.**",
       "paramStructure": "by-name",
       "params": [
         {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "9O2eIts+EjmZEl30FNTKQ3eiMVv2MgCsitLEHQ7m/Nk=",
+    "shasum": "EDo18GdUZYwGb9MlRwNGYq+8T0agDuEN4MMJ4hNO+ps=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onClientRequest/types.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/types.ts
@@ -1,6 +1,8 @@
 export enum ClientRequestMethod {
   SignAndSendTransactionWithoutConfirmation = 'signAndSendTransactionWithoutConfirmation',
-  OnConfirmSend = 'onConfirmSend',
+  ConfirmSend = 'confirmSend',
+  SignAndSendTransaction = 'signAndSendTransaction',
+  ComputeFee = 'computeFee',
   OnAddressInput = 'onAddressInput',
   OnAmountInput = 'onAmountInput',
 }

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -1,6 +1,14 @@
+import { AssetStruct, FeeType } from '@metamask/keyring-api';
 import { literal } from '@metamask/snaps-sdk';
 import type { Infer } from '@metamask/superstruct';
-import { array, object, string, boolean, enums } from '@metamask/superstruct';
+import {
+  array,
+  object,
+  string,
+  boolean,
+  enums,
+  optional,
+} from '@metamask/superstruct';
 import {
   CaipAssetTypeStruct,
   JsonRpcIdStruct,
@@ -8,8 +16,14 @@ import {
 } from '@metamask/utils';
 
 import { SendErrorCodes } from '../../services/send/types';
-import { SolanaSignAndSendTransactionInputStruct } from '../../services/wallet/structs';
 import {
+  SolanaSignAndSendTransactionInputStruct,
+  SolanaSignAndSendTransactionOptionsStruct,
+  ScopeStringStruct,
+} from '../../services/wallet/structs';
+import {
+  Base58Struct,
+  Base64Struct,
   PositiveNumberStringStruct,
   SolanaAddressStruct,
   UuidStruct,
@@ -18,6 +32,7 @@ import { ClientRequestMethod } from './types';
 
 /**
  * signAndSendTransactionWithoutConfirmation request/response validation.
+ * TODO: Deprecate this method.
  */
 export const SignAndSendTransactionWithoutConfirmationRequestStruct = object({
   jsonrpc: JsonRpcVersionStruct,
@@ -27,6 +42,31 @@ export const SignAndSendTransactionWithoutConfirmationRequestStruct = object({
   ),
   params: SolanaSignAndSendTransactionInputStruct,
 });
+
+/**
+ * signAndSendTransaction request/response validation.
+ */
+export const SignAndSendTransactionRequestParamsStruct = object({
+  transaction: Base64Struct,
+  accountId: UuidStruct,
+  scope: ScopeStringStruct,
+  options: optional(SolanaSignAndSendTransactionOptionsStruct),
+});
+
+export const SignAndSendTransactionRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.SignAndSendTransaction),
+  params: SignAndSendTransactionRequestParamsStruct,
+});
+
+export const SignAndSendTransactionResponseStruct = object({
+  transactionId: Base58Struct,
+});
+
+export type SignAndSendTransactionResponse = Infer<
+  typeof SignAndSendTransactionResponseStruct
+>;
 
 /**
  * onConfirmSend request/response validation.
@@ -41,7 +81,7 @@ export const OnConfirmSendRequestParamsStruct = object({
 export const OnConfirmSendRequestStruct = object({
   jsonrpc: JsonRpcVersionStruct,
   id: JsonRpcIdStruct,
-  method: literal(ClientRequestMethod.OnConfirmSend),
+  method: literal(ClientRequestMethod.ConfirmSend),
   params: OnConfirmSendRequestParamsStruct,
 });
 
@@ -85,3 +125,28 @@ export const ValidationResponseStruct = object({
 });
 
 export type ValidationResponse = Infer<typeof ValidationResponseStruct>;
+
+/**
+ * computeFee request/response validation.
+ */
+export const ComputeFeeRequestParamsStruct = object({
+  transaction: Base64Struct,
+  accountId: UuidStruct,
+  scope: ScopeStringStruct,
+});
+
+export const ComputeFeeRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.ComputeFee),
+  params: ComputeFeeRequestParamsStruct,
+});
+
+export const ComputeFeeResponseStruct = array(
+  object({
+    type: enums(Object.values(FeeType)),
+    asset: AssetStruct,
+  }),
+);
+
+export type ComputeFeeResponse = Infer<typeof ComputeFeeResponseStruct>;

--- a/packages/snap/src/core/handlers/onRpcRequest/index.ts
+++ b/packages/snap/src/core/handlers/onRpcRequest/index.ts
@@ -6,9 +6,10 @@ import { getFeeForTransaction } from './getFeeForTransaction';
 import { RpcRequestMethod, TestDappRpcRequestMethod } from './types';
 
 export const handlers: Record<RpcRequestMethod, OnRpcRequestHandler> = {
-  [RpcRequestMethod.StartSendTransactionFlow]: renderSend,
+  // TODO: Deprecate this method.
   [RpcRequestMethod.GetFeeForTransaction]: getFeeForTransaction,
 
+  [RpcRequestMethod.StartSendTransactionFlow]: renderSend,
   // Methods specific to the test dapp
   [TestDappRpcRequestMethod.ListWebSockets as any]: async () => {
     await eventEmitter.emitSync('onListWebSockets');

--- a/packages/snap/src/core/services/send/SendService.test.ts
+++ b/packages/snap/src/core/services/send/SendService.test.ts
@@ -109,7 +109,7 @@ describe('SendService', () => {
     const mockRequest: OnConfirmSendRequest = {
       jsonrpc: '2.0',
       id: '1',
-      method: ClientRequestMethod.OnConfirmSend,
+      method: ClientRequestMethod.ConfirmSend,
       params: {
         fromAccountId: mockAccount.id,
         toAddress: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,

--- a/packages/snap/src/core/services/wallet/structs.ts
+++ b/packages/snap/src/core/services/wallet/structs.ts
@@ -34,7 +34,7 @@ import { Base58Struct, Base64Struct } from '../../validation/structs';
  * @see https://github.com/anza-xyz/wallet-standard/tree/master/packages/core/features/src
  */
 
-const ScopeStringStruct = enums(Object.values(Network));
+export const ScopeStringStruct = enums(Object.values(Network));
 
 // Sanitizing structs that transform values during validation
 const SanitizedSolanaAddressStruct = coerce(
@@ -158,7 +158,7 @@ const SolanaSignTransactionInputStruct = type({
   options: optional(SolanaSignTransactionOptionsStruct),
 });
 
-const SolanaSignAndSendTransactionOptionsStruct = type({
+export const SolanaSignAndSendTransactionOptionsStruct = type({
   ...SolanaSignTransactionOptionsStruct.schema,
   /** Desired commitment level. If provided, confirm the transaction after sending. */
   commitment: optional(SolanaTransactionCommitmentStruct),

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -231,6 +231,7 @@ const clientRequestHandler = new ClientRequestHandler(
   walletService,
   logger,
   sendService,
+  transactionHelper,
 );
 
 const snapContext: SnapExecutionContext = {


### PR DESCRIPTION
This pull request updates the Solana Snap's JSON-RPC API to introduce new transaction methods, deprecate older ones, and add comprehensive tests for the new functionality. The changes also include internal refactoring to support fee computation and transaction handling in a more robust and extensible way.

**API enhancements and deprecations:**

* Added a new `signAndSendTransaction` method to the OpenRPC schema, replacing the older `signAndSendTransactionWithoutConfirmation` (now marked as deprecated). The new method provides clearer parameterization, return types, and examples.
* Introduced a new `computeFee` method, allowing clients to calculate transaction fees before execution. The old `getFeeForTransaction` method is now deprecated. 
* Renamed the `onConfirmSend` method to `confirmSend` and updated related result and example names for consistency. 

**Internal codebase and test improvements:**

* Refactored `ClientRequestHandler` to support the new `signAndSendTransaction` and `computeFee` methods, including parameter validation, error handling, and integration with the new `TransactionHelper` service.
* Enhanced test coverage in `ClientRequestHandler.test.ts` for the new and updated methods, including success and error scenarios for `signAndSendTransaction`, `computeFee`, and `confirmSend`.