### PR TITLE
Further optimize WS connection management

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "+XvYsmNZWym3Vau8lR8ABhOBqUOwmECiscVK/jofH6k=",
+    "shasum": "CIOmoT6tMTs/Y9JgBUCe79nRLvkYc2NnmBIUt14YuAQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -16,10 +16,13 @@
         "registry": "https://registry.npmjs.org/"
       }
     },
-    "locales": ["locales/en.json"]
+    "locales": [
+      "locales/en.json"
+    ]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {}
+    "https://portfolio.metamask.io": {},
+    "http://localhost:3000": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -27,11 +30,18 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": ["https://portfolio.metamask.io"]
+      "allowedOrigins": [
+        "https://portfolio.metamask.io",
+        "http://localhost:3000"
+      ]
     },
     "snap_getBip32Entropy": [
       {
-        "path": ["m", "44'", "501'"],
+        "path": [
+          "m",
+          "44'",
+          "501'"
+        ],
         "curve": "ed25519"
       }
     ],

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "CIOmoT6tMTs/Y9JgBUCe79nRLvkYc2NnmBIUt14YuAQ=",
+    "shasum": "kmKHnziM029CtOiQFPTsOVO5znZF2RTHbg4Mc/+DkFs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -16,13 +16,10 @@
         "registry": "https://registry.npmjs.org/"
       }
     },
-    "locales": [
-      "locales/en.json"
-    ]
+    "locales": ["locales/en.json"]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {},
-    "http://localhost:3000": {}
+    "https://portfolio.metamask.io": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -30,18 +27,11 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": [
-        "https://portfolio.metamask.io",
-        "http://localhost:3000"
-      ]
+      "allowedOrigins": ["https://portfolio.metamask.io"]
     },
     "snap_getBip32Entropy": [
       {
-        "path": [
-          "m",
-          "44'",
-          "501'"
-        ],
+        "path": ["m", "44'", "501'"],
         "curve": "ed25519"
       }
     ],

--- a/packages/snap/src/core/services/analytics/AnalyticsService.ts
+++ b/packages/snap/src/core/services/analytics/AnalyticsService.ts
@@ -6,7 +6,6 @@ import type { SolanaKeyringAccount } from '../../../entities';
 import type { Network, TransactionMetadata } from '../../constants/solana';
 import type { ILogger } from '../../utils/logger';
 import logger, { createPrefixedLogger } from '../../utils/logger';
-import type { JsonRpcWebSocketMessage } from '../subscriptions/parseWebSocketMessage';
 import type {
   ScanStatus,
   SecurityAlertResponse,
@@ -35,23 +34,6 @@ export class AnalyticsService {
         },
       },
     });
-  }
-
-  async trackInactiveWebSocketMessage(
-    message: JsonRpcWebSocketMessage<unknown>,
-  ): Promise<void> {
-    try {
-      await this.#trackEvent('Inactive Solana WebSocket Message', {
-        message: 'Inactive Solana web socket message',
-        method: message.method,
-        subscription_id: message?.params?.subscription,
-        timestamp: Date.now(),
-      });
-    } catch (error) {
-      this.#logger.warn('Error tracking inactive web socket message', {
-        error,
-      });
-    }
   }
 
   async trackEventTransactionAdded(

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -62,8 +62,6 @@ type TokenAccountWithMetadata = {
 export class AssetsService {
   readonly #logger: ILogger;
 
-  readonly #loggerPrefix = '[🪙 AssetsService]';
-
   readonly #connection: SolanaConnection;
 
   readonly #configProvider: ConfigProvider;
@@ -224,11 +222,7 @@ export class AssetsService {
   async getAssetsMetadata(
     assetTypes: CaipAssetType[],
   ): Promise<Record<CaipAssetType, AssetMetadata | null>> {
-    this.#logger.log(
-      this.#loggerPrefix,
-      'Fetching metadata for assets',
-      assetTypes,
-    );
+    this.#logger.log('Fetching metadata for assets', assetTypes);
 
     const { nativeAssetTypes, tokenAssetTypes, nftAssetTypes } =
       this.#splitAssetsByType(assetTypes);

--- a/packages/snap/src/core/services/subscriptions/SubscriptionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/SubscriptionService.test.ts
@@ -183,7 +183,6 @@ describe('SubscriptionService', () => {
       mockConfigProvider,
       mockEventEmitter,
       mockLogger,
-      mockAnalyticsService,
     );
   });
 

--- a/packages/snap/src/core/services/subscriptions/SubscriptionService.ts
+++ b/packages/snap/src/core/services/subscriptions/SubscriptionService.ts
@@ -15,14 +15,9 @@ import type {
 import { subscribeMethodToUnsubscribeMethod } from '../../../entities';
 import type { EventEmitter } from '../../../infrastructure';
 import type { Network } from '../../constants/solana';
-import { getClientStatus } from '../../utils/interface';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
-import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { ConfigProvider } from '../config';
-import {
-  type JsonRpcWebSocketMessage,
-  parseWebSocketMessage,
-} from './parseWebSocketMessage';
+import { parseWebSocketMessage } from './parseWebSocketMessage';
 import type { SubscriptionRepository } from './SubscriptionRepository';
 import type { WebSocketConnectionService } from './WebSocketConnectionService';
 
@@ -47,8 +42,6 @@ export class SubscriptionService {
 
   readonly #logger: ILogger;
 
-  readonly #analyticsService: AnalyticsService;
-
   readonly #notificationHandlers: Map<string, Set<NotificationHandler>> =
     new Map();
 
@@ -58,14 +51,12 @@ export class SubscriptionService {
     configProvider: ConfigProvider,
     eventEmitter: EventEmitter,
     logger: ILogger,
-    analyticsService: AnalyticsService,
   ) {
     this.#connectionService = connectionService;
     this.#subscriptionRepository = subscriptionRepository;
     this.#configProvider = configProvider;
     this.#eventEmitter = eventEmitter;
     this.#logger = createPrefixedLogger(logger, '[🔔 SubscriptionService]');
-    this.#analyticsService = analyticsService;
 
     this.#bindHandlers();
   }
@@ -238,27 +229,6 @@ export class SubscriptionService {
     return this.#subscriptionRepository.getAll();
   }
 
-  async #handleTrackInactiveWebSocketMessage(
-    message: JsonRpcWebSocketMessage<unknown>,
-  ): Promise<void> {
-    /**
-     * Track inactive web socket messages only when the client is not active.
-     */
-    try {
-      const { active } = await getClientStatus();
-
-      if (active) {
-        return;
-      }
-
-      await this.#analyticsService.trackInactiveWebSocketMessage(message);
-    } catch (error) {
-      this.#logger.warn('Error tracking inactive web socket message', {
-        error,
-      });
-    }
-  }
-
   async #handleWebSocketEvent(message: WebSocketEvent): Promise<void> {
     // We only care about actual messages, not open or close events, which are handled by the connection service.
     if (message.type !== 'message') {
@@ -293,9 +263,6 @@ export class SubscriptionService {
         }
         break;
     }
-
-    // Track inactive web socket messages only after handling the message.
-    await this.#handleTrackInactiveWebSocketMessage(parsedMessage);
   }
 
   async #routeNotification(

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../entities';
 import type { EventEmitter } from '../../../infrastructure';
 import type { Network } from '../../constants/solana';
+import { getClientStatus } from '../../utils/interface';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { ConfigProvider } from '../config';
 import type { WebSocketConnectionRepository } from './WebSocketConnectionRepository';
@@ -70,25 +71,43 @@ export class WebSocketConnectionService {
 
   #bindHandlers(): void {
     // Aliases to make the code more readable
-    const openAll = this.#openConnectionsForActiveNetworks.bind(this);
-    const closeAll = this.#closeAllConnections.bind(this);
+    const setup = this.#setupConnections.bind(this);
+    const open = this.#openConnectionsForActiveNetworks.bind(this);
+    const close = this.#closeAllConnections.bind(this);
+    const list = this.#listConnections.bind(this);
+    const handleEvent = this.#handleWebSocketEvent.bind(this);
 
-    // When the extension becomes active, starts, or that the snap is updated / installed, the Snap platform might have lost its previously opened websockets, so we make sure the are open
-    this.#eventEmitter.on('onStart', openAll);
-    this.#eventEmitter.on('onUpdate', openAll);
-    this.#eventEmitter.on('onInstall', openAll);
-    this.#eventEmitter.on('onActive', openAll);
+    // When the extension starts, or that the snap is updated / installed, the Snap platform looses previously opened web socket connections,
+    // so we need to setup them up again, if needed.
+    this.#eventEmitter.on('onStart', setup);
+    this.#eventEmitter.on('onUpdate', setup);
+    this.#eventEmitter.on('onInstall', setup);
+
+    // When the extension becomes active, we open all connections
+    this.#eventEmitter.on('onActive', open);
 
     // When the extension becomes inactive, we close all connections
-    this.#eventEmitter.on('onInactive', closeAll);
+    this.#eventEmitter.on('onInactive', close);
 
-    this.#eventEmitter.on(
-      'onWebSocketEvent',
-      this.#handleWebSocketEvent.bind(this),
-    );
+    this.#eventEmitter.on('onWebSocketEvent', handleEvent);
 
-    // Specific binds to enable manual testing from the test dapp
-    this.#eventEmitter.on('onListWebSockets', this.#listConnections.bind(this));
+    // Specific bind to enable manual testing from the test dapp
+    this.#eventEmitter.on('onListWebSockets', list);
+  }
+
+  /**
+   * Sets up the connections.
+   * - If the client is active, we open them for all active networks.
+   * - If the client is inactive, we close them all.
+   */
+  async #setupConnections(): Promise<void> {
+    const { active } = await getClientStatus();
+
+    if (active) {
+      await this.#openConnectionsForActiveNetworks();
+    } else {
+      await this.#closeAllConnections();
+    }
   }
 
   async #openConnectionsForActiveNetworks(): Promise<void> {

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -101,6 +101,8 @@ export class WebSocketConnectionService {
    * - If the client is inactive, we close them all.
    */
   async #setupConnections(): Promise<void> {
+    this.#logger.log(`Setting up connections`);
+
     const { active } = await getClientStatus();
 
     if (active) {
@@ -146,6 +148,7 @@ export class WebSocketConnectionService {
       this.#logger.log(`✅ Connection for network ${network} already exists`);
       return;
     }
+
     await this.#connectionRepository.save({
       network,
       url: webSocketUrl,

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -25,7 +25,7 @@ import { addressToCaip10 } from '../../utils/addressToCaip10';
 import { deriveSolanaKeypair } from '../../utils/deriveSolanaKeypair';
 import { getSolanaExplorerUrl } from '../../utils/getSolanaExplorerUrl';
 import type { ILogger } from '../../utils/logger';
-import logger from '../../utils/logger';
+import logger, { createPrefixedLogger } from '../../utils/logger';
 import {
   Base58Struct,
   Base64Struct,
@@ -62,8 +62,6 @@ export class WalletService {
 
   readonly #logger: ILogger;
 
-  readonly #loggerPrefix = '[👛 WalletService]';
-
   constructor(
     connection: SolanaConnection,
     transactionHelper: TransactionHelper,
@@ -73,7 +71,7 @@ export class WalletService {
     this.#connection = connection;
     this.#transactionHelper = transactionHelper;
     this.#signatureMonitor = signatureMonitor;
-    this.#logger = _logger;
+    this.#logger = createPrefixedLogger(_logger, '[👛 WalletService]');
   }
 
   /**
@@ -95,7 +93,7 @@ export class WalletService {
     scope: Network,
     request: SolanaWalletRequest,
   ): Promise<Caip10Address> {
-    this.#logger.log(this.#loggerPrefix, 'Resolving account address', {
+    this.#logger.log('Resolving account address', {
       keyringAccounts,
       scope,
       request,
@@ -196,7 +194,7 @@ export class WalletService {
     account: SolanaKeyringAccount,
     request: KeyringRequest,
   ): Promise<SolanaSignTransactionResponse> {
-    this.#logger.log(this.#loggerPrefix, 'Signing transaction', {
+    this.#logger.log('Signing transaction', {
       account,
       request,
     });
@@ -267,11 +265,7 @@ export class WalletService {
     origin: string,
     options?: SolanaSignAndSendTransactionOptions,
   ): Promise<SolanaSignAndSendTransactionResponse> {
-    this.#logger.log(
-      this.#loggerPrefix,
-      'Signing and sending transaction',
-      account,
-    );
+    this.#logger.log('Signing and sending transaction', account);
 
     const signConfig: DecompileTransactionMessageFetchingLookupTablesConfig =
       options?.minContextSlot
@@ -357,7 +351,7 @@ export class WalletService {
     account: SolanaKeyringAccount,
     request: KeyringRequest,
   ): Promise<SolanaSignMessageResponse> {
-    this.#logger.log(this.#loggerPrefix, 'Signing message', account, request);
+    this.#logger.log('Signing message', account, request);
 
     assert(request.request, SolanaSignMessageRequestStruct);
 
@@ -423,7 +417,7 @@ export class WalletService {
     account: SolanaKeyringAccount,
     request: KeyringRequest,
   ): Promise<SolanaSignInResponse> {
-    this.#logger.log(this.#loggerPrefix, 'Signing in', account, request);
+    this.#logger.log('Signing in', account, request);
 
     assert(request.request, SolanaSignInRequestStruct);
 
@@ -482,7 +476,7 @@ export class WalletService {
     signatureBase58: Infer<typeof Base58Struct>,
     messageBase64: Infer<typeof Base64Struct>,
   ): Promise<boolean> {
-    this.#logger.log(this.#loggerPrefix, 'Verifying signature', {
+    this.#logger.log('Verifying signature', {
       account,
       signatureBase58,
       messageBase64,

--- a/packages/snap/src/infrastructure/event-emitter/EventEmitter.ts
+++ b/packages/snap/src/infrastructure/event-emitter/EventEmitter.ts
@@ -1,4 +1,4 @@
-import type { ILogger } from '../../core/utils/logger';
+import { createPrefixedLogger, type ILogger } from '../../core/utils/logger';
 
 type Listener = (data?: any) => Promise<void>;
 
@@ -18,12 +18,10 @@ type Listener = (data?: any) => Promise<void>;
 export class EventEmitter {
   readonly #logger: ILogger;
 
-  readonly #loggerPrefix = '[⚡ EventEmitter]';
-
   readonly #listeners: Map<string, Set<Listener>> = new Map();
 
   constructor(logger: ILogger) {
-    this.#logger = logger;
+    this.#logger = createPrefixedLogger(logger, '[⚡ EventEmitter]');
   }
 
   /**
@@ -32,7 +30,7 @@ export class EventEmitter {
    * @param listener - The listener to call when the event is emitted.
    */
   on(event: string, listener: Listener) {
-    this.#logger.info(this.#loggerPrefix, `Adding listener for event ${event}`);
+    this.#logger.info(`Adding listener for event ${event}`);
 
     if (!this.#listeners.has(event)) {
       this.#listeners.set(event, new Set());
@@ -47,10 +45,7 @@ export class EventEmitter {
    * @param listener - The listener to remove.
    */
   off(event: string, listener: Listener) {
-    this.#logger.info(
-      this.#loggerPrefix,
-      `Removing listener for event ${event}`,
-    );
+    this.#logger.info(`Removing listener for event ${event}`);
 
     const listeners = this.#listeners.get(event);
     if (listeners) {
@@ -71,7 +66,7 @@ export class EventEmitter {
    * @param data - The data to pass to the listeners.
    */
   async emitSync(event: string, data?: any): Promise<void> {
-    this.#logger.info(this.#loggerPrefix, `Emitting event ${event}`);
+    this.#logger.info(`Emitting event ${event}`);
     const listeners = this.#listeners.get(event);
 
     if (listeners) {
@@ -88,16 +83,10 @@ export class EventEmitter {
    */
   removeAllListeners(event?: string) {
     if (event) {
-      this.#logger.info(
-        this.#loggerPrefix,
-        `Removing all listeners for event ${event}`,
-      );
+      this.#logger.info(`Removing all listeners for event ${event}`);
       this.#listeners.delete(event);
     } else {
-      this.#logger.info(
-        this.#loggerPrefix,
-        `Removing all listeners for all events`,
-      );
+      this.#logger.info('Removing all listeners for all events');
       this.#listeners.clear();
     }
   }

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -109,7 +109,6 @@ const subscriptionService = new SubscriptionService(
   configProvider,
   eventEmitter,
   logger,
-  analyticsService,
 );
 
 const transactionHelper = new TransactionHelper(connection, logger);


### PR DESCRIPTION
- Optimize the WS connections lifecycle. Before, we were always opening connections `onStart`/`onInstall`/`onUpdate`, we were opening connections all the time. Now we open them only if client is active.
- Remove the tracking of event `Inactive Solana web socket message`. It's not relevant anymore now that we close websockets onInactive.
- Standardize logging in a few places.