### PR TITLE
fix: only monitor fully signed transactions

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "aZawoaZNg/UUAhbXkDbJtrT25yjMIzzODaUHVNB64kw=",
+    "shasum": "0qjsY/LBK9balbyxCUtLxYOOsOWUihNgO9IigakX2M0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,7 +19,8 @@
     "locales": ["locales/en.json"]
   },
   "initialConnections": {
-    "https://portfolio.metamask.io": {}
+    "https://portfolio.metamask.io": {},
+    "http://localhost:3000": {}
   },
   "initialPermissions": {
     "endowment:rpc": {
@@ -27,7 +28,10 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": ["https://portfolio.metamask.io"]
+      "allowedOrigins": [
+        "https://portfolio.metamask.io",
+        "http://localhost:3000"
+      ]
     },
     "snap_getBip32Entropy": [
       {

--- a/packages/snap/src/core/services/signer/Signer.test.ts
+++ b/packages/snap/src/core/services/signer/Signer.test.ts
@@ -16,7 +16,9 @@ import {
 } from '../../sdk-extensions/transaction-messages';
 import { deriveSolanaKeypairMock } from '../../test/mocks/utils/deriveSolanaKeypair';
 import logger from '../../utils/logger';
+import type { SolanaConnection } from '../connection';
 import { createMockConnection } from '../mocks/mockConnection';
+import { MOCK_SIGN_SCENARIO_JUPITERZ_WITH_DIFFERENT_FEE_PAYER } from './mocks/jupiterzWithDifferentFeePayer';
 import { MOCK_EXECUTION_SCENARIOS } from './mocks/scenarios';
 import { Signer } from './Signer';
 
@@ -36,17 +38,13 @@ jest.mock('../../utils/deriveSolanaKeypair', () => ({
 
 describe('Signer', () => {
   const mockScope = Network.Mainnet;
-
-  const mockRpcResponse = {
-    send: jest.fn(),
-  };
-
-  const mockConnection = createMockConnection();
+  let mockConnection: SolanaConnection;
 
   let signer: Signer;
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockConnection = createMockConnection();
     signer = new Signer(mockConnection, logger);
   });
 
@@ -64,11 +62,11 @@ describe('Signer', () => {
 
     beforeEach(async () => {
       jest.clearAllMocks();
+
       signer = new Signer(mockConnection, logger);
+
       jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
         ...mockConnection.getRpc(mockScope),
-        getLatestBlockhash: () => mockRpcResponse,
-        getFeeForMessage: () => mockRpcResponse,
         getMultipleAccounts: jest.fn().mockReturnValue({
           send: jest
             .fn()
@@ -85,6 +83,7 @@ describe('Signer', () => {
             fromAccount,
             scope,
           );
+
           const resultSignature = getSignatureFromTransaction(result);
 
           expect(result).toStrictEqual(signedTransaction);
@@ -122,6 +121,69 @@ describe('Signer', () => {
             ),
           ).toBe(true);
         });
+      });
+    });
+  });
+
+  describe('when the fee payer is different from the account', () => {
+    it('signs the transaction message successfully', async () => {
+      const { scope, transactionRequestBase64Encoded, userAccount } =
+        MOCK_SIGN_SCENARIO_JUPITERZ_WITH_DIFFERENT_FEE_PAYER;
+
+      const partiallySignedTransaction = await signer.partiallySignBase64String(
+        transactionRequestBase64Encoded,
+        userAccount,
+        scope,
+      );
+
+      expect(partiallySignedTransaction).toStrictEqual({
+        lifetimeConstraint: {
+          blockhash: '8o7LFQ8aJ1eZkB1ShjnwzwnfkptjbRoD8gXPkib7K1DR',
+          lastValidBlockHeight: 18446744073709551615n,
+        },
+        messageBytes: new Uint8Array([
+          128, 2, 0, 6, 12, 166, 175, 172, 132, 2, 105, 14, 33, 122, 105, 220,
+          7, 50, 189, 98, 255, 64, 29, 138, 160, 54, 67, 17, 144, 23, 120, 198,
+          47, 124, 254, 220, 189, 153, 176, 2, 143, 157, 158, 175, 50, 134, 226,
+          145, 237, 10, 87, 130, 63, 185, 200, 241, 76, 205, 92, 21, 136, 75,
+          157, 88, 79, 89, 248, 223, 116, 15, 102, 248, 21, 53, 113, 144, 71,
+          137, 127, 26, 38, 205, 4, 248, 209, 38, 217, 101, 67, 105, 42, 24, 55,
+          43, 166, 48, 148, 104, 82, 164, 117, 48, 36, 129, 80, 117, 87, 70, 77,
+          249, 251, 108, 166, 221, 92, 72, 25, 62, 193, 83, 16, 86, 187, 56, 36,
+          212, 5, 67, 0, 96, 91, 209, 153, 132, 236, 176, 69, 168, 106, 118,
+          244, 164, 143, 111, 220, 64, 42, 101, 164, 63, 70, 9, 95, 49, 228,
+          192, 29, 10, 64, 248, 0, 215, 209, 158, 155, 14, 37, 7, 136, 203, 142,
+          76, 71, 239, 255, 180, 111, 163, 36, 124, 167, 121, 83, 255, 163, 42,
+          243, 187, 206, 39, 92, 25, 109, 6, 96, 240, 240, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 74, 88, 73, 251, 114, 163, 187, 233, 31, 220, 91, 14, 106, 87,
+          246, 60, 90, 28, 180, 91, 32, 103, 166, 237, 12, 172, 211, 99, 149,
+          200, 161, 2, 3, 6, 70, 111, 229, 33, 23, 50, 255, 236, 173, 186, 114,
+          195, 155, 231, 188, 140, 229, 187, 197, 247, 18, 107, 44, 67, 155, 58,
+          64, 0, 0, 0, 198, 250, 122, 243, 190, 219, 173, 58, 61, 101, 243, 106,
+          171, 201, 116, 49, 177, 187, 228, 194, 210, 246, 224, 228, 124, 166,
+          2, 3, 69, 47, 93, 97, 6, 155, 136, 87, 254, 171, 129, 132, 251, 104,
+          127, 99, 70, 24, 192, 53, 218, 196, 57, 220, 26, 235, 59, 85, 152,
+          160, 240, 0, 0, 0, 0, 1, 6, 221, 246, 225, 215, 101, 161, 147, 217,
+          203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237, 95, 91, 55, 145,
+          58, 140, 245, 133, 126, 255, 0, 169, 115, 209, 175, 103, 12, 170, 169,
+          61, 216, 128, 84, 178, 158, 117, 225, 255, 22, 37, 225, 41, 247, 26,
+          101, 28, 81, 187, 145, 38, 13, 50, 65, 0, 3, 8, 0, 9, 3, 57, 41, 0, 0,
+          0, 0, 0, 0, 8, 0, 5, 2, 126, 144, 0, 0, 7, 12, 1, 0, 4, 2, 7, 5, 9,
+          11, 10, 11, 6, 3, 35, 168, 96, 183, 163, 92, 10, 40, 160, 64, 66, 15,
+          0, 0, 0, 0, 0, 151, 90, 69, 0, 0, 0, 0, 0, 20, 154, 210, 104, 0, 0, 0,
+          0, 2, 0, 0, 0,
+        ]),
+        signatures: {
+          CDg3bPoM21fSXEzrXWHWyJR33JHX6xaYboq5p7s4uo48: null,
+          BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP: new Uint8Array([
+            21, 3, 51, 147, 54, 231, 170, 228, 92, 92, 247, 188, 98, 138, 98,
+            136, 235, 184, 108, 14, 188, 100, 77, 157, 190, 84, 23, 137, 255,
+            140, 87, 97, 211, 1, 26, 226, 180, 23, 184, 123, 0, 87, 202, 186,
+            32, 95, 120, 125, 33, 74, 148, 160, 87, 80, 246, 228, 105, 28, 129,
+            56, 232, 165, 79, 0,
+          ]),
+        },
       });
     });
   });

--- a/packages/snap/src/core/services/signer/Signer.ts
+++ b/packages/snap/src/core/services/signer/Signer.ts
@@ -30,7 +30,7 @@ import {
   setTransactionMessageLifetimeUsingBlockhashIfMissing,
 } from '../../sdk-extensions/transaction-messages';
 import { deriveSolanaKeypair } from '../../utils/deriveSolanaKeypair';
-import type { ILogger } from '../../utils/logger';
+import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { Base64Struct } from '../../validation/structs';
 import type { SolanaConnection } from '../connection';
 
@@ -46,7 +46,7 @@ export class Signer {
 
   constructor(connection: SolanaConnection, logger: ILogger) {
     this.#connection = connection;
-    this.#logger = logger;
+    this.#logger = createPrefixedLogger(logger, '[🖋️ Signer]');
   }
 
   /**
@@ -69,6 +69,13 @@ export class Signer {
     network: Network,
     config?: DecompileTransactionMessageFetchingLookupTablesConfig,
   ): Promise<Transaction> {
+    this.#logger.log('Partially sign base64 string', {
+      base64String,
+      account,
+      network,
+      config,
+    });
+
     const rpc = this.#connection.getRpc(network);
 
     // The received base64 string can either represent a transaction or a transaction message.

--- a/packages/snap/src/core/services/signer/mocks/jupiterzWithDifferentFeePayer.ts
+++ b/packages/snap/src/core/services/signer/mocks/jupiterzWithDifferentFeePayer.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  address,
+  blockhash,
+  type CompilableTransactionMessage,
+} from '@solana/kit';
+
+import { Network } from '../../../constants/solana';
+import {
+  MOCK_SOLANA_KEYRING_ACCOUNT_0,
+  MOCK_SOLANA_KEYRING_ACCOUNTS_PRIVATE_KEY_BYTES,
+} from '../../../test/mocks/solana-keyring-accounts';
+
+const scope = Network.Devnet;
+
+const userAccount = MOCK_SOLANA_KEYRING_ACCOUNT_0;
+
+const fromAccountPrivateKeyBytes =
+  MOCK_SOLANA_KEYRING_ACCOUNTS_PRIVATE_KEY_BYTES[userAccount.id]!;
+
+const transactionRequestBase64Encoded =
+  'AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAIABgymr6yEAmkOIXpp3AcyvWL/QB2KoDZDEZAXeMYvfP7cvZmwAo+dnq8yhuKR7QpXgj+5yPFMzVwViEudWE9Z+N90DiUHiMuOTEfv/7RvoyR8p3lT/6Mq87vOJ1wZbQZg8PAPZvgVNXGQR4l/GibNBPjRJtllQ2kqGDcrpjCUaFKkdTAkgVB1V0ZN+ftspt1cSBk+wVMQVrs4JNQFQwBgW9GZhOywRahqdvSkj2/cQCplpD9GCV8x5MAdCkD4ANfRnpsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAABpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqUpYSftyo7vpH9xbDmpX9jxaHLRbIGem7Qys02OVyKECxvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWFz0a9nDKqpPdiAVLKedeH/FiXhKfcaZRxRu5EmDTJBAAMHAAkDOSkAAAAAAAAHAAUCfpAAAAoMAQAFAwoCCwkICQYEI6hgt6NcCiigQEIPAAAAAACXWkUAAAAAABSa0mgAAAAAAgAAAA==';
+
+const transactionMessage: CompilableTransactionMessage = {
+  instructions: [
+    {
+      programAddress: address('ComputeBudget111111111111111111111111111111'),
+      data: new Uint8Array([3, 57, 41, 0, 0, 0, 0, 0, 0]),
+    },
+    {
+      programAddress: address('ComputeBudget111111111111111111111111111111'),
+      data: new Uint8Array([2, 126, 144, 0, 0]),
+    },
+    {
+      programAddress: address('61DFfeTKM7trxYcPQCM78bJ794ddZprZpAwAnLiwTpYH'),
+      accounts: [
+        { address: address(userAccount.address), role: 3 },
+        {
+          address: address('CDg3bPoM21fSXEzrXWHWyJR33JHX6xaYboq5p7s4uo48'),
+          role: 3,
+        },
+        {
+          address: address('9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg'),
+          role: 1,
+        },
+        {
+          address: address('238BYhc1qz4S62GBFGhFm3233PC9S6dmhtikjzKendsz'),
+          role: 1,
+        },
+        {
+          address: address('61DFfeTKM7trxYcPQCM78bJ794ddZprZpAwAnLiwTpYH'),
+          role: 0,
+        },
+        {
+          address: address('xDTVdH7CGuDhRebhtfSxE33ZL1crUKwM3GnSb9a7DKm'),
+          role: 1,
+        },
+        {
+          address: address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+          role: 0,
+        },
+        {
+          address: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+          role: 0,
+        },
+        {
+          address: address('So11111111111111111111111111111111111111112'),
+          role: 0,
+        },
+        {
+          address: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+          role: 0,
+        },
+        { address: address('11111111111111111111111111111111'), role: 0 },
+        {
+          address: address('4EvracGAstedg3H7oTkERRshLvQ7hwKjSc9BuWgegFjN'),
+          role: 1,
+        },
+      ],
+      data: new Uint8Array([
+        168, 96, 183, 163, 92, 10, 40, 160, 64, 66, 15, 0, 0, 0, 0, 0, 151, 90,
+        69, 0, 0, 0, 0, 0, 20, 154, 210, 104, 0, 0, 0, 0, 2, 0, 0,
+      ]),
+    },
+  ],
+  version: 0,
+  feePayer: {
+    address: address('CDg3bPoM21fSXEzrXWHWyJR33JHX6xaYboq5p7s4uo48'), // Note that this is NOT the user address
+  },
+  lifetimeConstraint: {
+    blockhash: blockhash('8o7LFQ8aJ1eZkB1ShjnwzwnfkptjbRoD8gXPkib7K1DR'),
+    lastValidBlockHeight: 18446744073709551615n,
+  },
+};
+
+export const MOCK_SIGN_SCENARIO_JUPITERZ_WITH_DIFFERENT_FEE_PAYER = {
+  scope,
+  userAccount,
+  fromAccountPrivateKeyBytes,
+  transactionRequestBase64Encoded,
+  transactionMessage,
+};

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -192,15 +192,25 @@ export class WalletService {
 
     assert(result, SolanaSignTransactionResponseStruct);
 
-    const signature = getSignatureFromTransaction(partiallySignedTransaction);
-
-    await this.#signatureMonitor.monitor(
-      signature,
-      account.id,
-      'confirmed',
-      scope,
-      origin,
-    );
+    // If the transaction is fully signed, we can monitor it.
+    try {
+      assertTransactionIsFullySigned(partiallySignedTransaction);
+      const signature = getSignatureFromTransaction(partiallySignedTransaction);
+      await this.#signatureMonitor.monitor(
+        signature,
+        account.id,
+        'confirmed',
+        scope,
+        origin,
+      );
+    } catch (error) {
+      this.#logger.warn(
+        'Transaction is not fully signed, skipping monitoring',
+        {
+          error,
+        },
+      );
+    }
 
     return result;
   }


### PR DESCRIPTION
# Support JupiterZ transactions with different fee payers

Adds support for signing transactions where the fee payer differs from the user's account, enabling users to interact with JupiterZ and other protocols that pay transaction fees on behalf of users.

## Key Changes
- Fixed signature extraction logic to handle partially signed transactions
- Previously, the snap assumed all transactions would be fully signed after wallet signing
- This assumption broke when handling JupiterZ transactions where the fee payer differs from the user's account
- JupiterZ transactions remain partially signed after wallet signing (JupiterZ completes signing before broadcast)

## Technical Details
- Enhanced transaction signing flow to properly handle different fee payer scenarios
- Added comprehensive test coverage for JupiterZ transaction patterns
- Ensured proper partial signing behavior when fee payer ≠ signing account

The fix ensures the wallet can seamlessly integrate with JupiterZ and similar protocols that implement fee sponsorship mechanisms.