### PR TITLE
fix: remove timestamp 1min validation

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "d2fv2SjHgzlXXfs7WWGefQMKYUDqjWpPu7xjVv1XUIw=",
+    "shasum": "MekbKRzGWpqzRaTuvbRJPH6vZUQBIGRqs8FKQX2X+/8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
@@ -100,39 +100,11 @@ describe('validation', () => {
     ])('rejects messages with invalid timestamps: "%s"', (utf8Message) => {
       const message = toBase64(utf8Message);
       // eslint-disable-next-line jest/require-to-throw-message
-      expect(() => assert(message, RewardsMessageStruct)).toThrow();
+      expect(() => assert(message, RewardsMessageStruct)).toThrow(
+        'Invalid timestamp',
+      );
       expect(is(message, RewardsMessageStruct)).toBe(false);
     });
-
-    it.each([
-      `rewards,${validSolanaAddress},${currentTimestamp - 120}`, // 2 minutes ago
-      `rewards,${validSolanaAddress},${currentTimestamp + 120}`, // 2 minutes in future
-      `rewards,${validSolanaAddress},${currentTimestamp - 61}`, // Just over 1 minute ago
-      `rewards,${validSolanaAddress},${currentTimestamp + 61}`, // Just over 1 minute in future
-    ])(
-      'rejects messages with timestamps outside 1-minute window: "%s"',
-      (utf8Message) => {
-        const message = toBase64(utf8Message);
-        expect(() => assert(message, RewardsMessageStruct)).toThrow(
-          'Timestamp must be within 1 minute',
-        );
-        expect(is(message, RewardsMessageStruct)).toBe(false);
-      },
-    );
-
-    it.each([
-      `rewards,${validSolanaAddress},${currentTimestamp - 60}`, // Exactly 1 minute ago
-      `rewards,${validSolanaAddress},${currentTimestamp + 60}`, // Exactly 1 minute in future
-      `rewards,${validSolanaAddress},${currentTimestamp - 59}`, // Just under 1 minute ago
-      `rewards,${validSolanaAddress},${currentTimestamp + 59}`, // Just under 1 minute in future
-    ])(
-      'accepts messages with timestamps at boundary of 1-minute window: "%s"',
-      (utf8Message) => {
-        const message = toBase64(utf8Message);
-        expect(() => assert(message, RewardsMessageStruct)).not.toThrow();
-        expect(is(message, RewardsMessageStruct)).toBe(true);
-      },
-    );
 
     it.each([
       123, // Number

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -166,13 +166,15 @@ export function parseRewardsMessage(base64Message: string): {
   if (!is(timestampPart, PositiveNumberStringStruct)) {
     throw new Error('Invalid timestamp format');
   }
-  const timestamp = parseInt(timestampPart, 10);
 
-  // Check if timestamp is within 1 minute of current time (60 seconds = 60000ms)
-  const currentTime = Math.floor(Date.now() / 1000); // Current time in seconds
-  const timeDifference = Math.abs(currentTime - timestamp);
-  if (timeDifference > 60) {
-    throw new Error('Timestamp must be within 1 minute of current time');
+  // Ensure timestamp is an integer (no decimals)
+  if (timestampPart.includes('.')) {
+    throw new Error('Invalid timestamp');
+  }
+
+  const timestamp = parseInt(timestampPart, 10);
+  if (timestamp <= 0) {
+    throw new Error('Invalid timestamp');
   }
 
   return {
@@ -187,7 +189,7 @@ export function parseRewardsMessage(base64Message: string): {
  * - Must be valid base64
  * - When decoded, must start with 'rewards,'
  * - Must contain a valid Solana address
- * - Must contain a timestamp within 1 minute of current time
+ * - Must contain a valid timestamp
  */
 export const RewardsMessageStruct = refine(
   Base64Struct,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the 1-minute timestamp window check for rewards messages, enforcing only positive integer timestamps; updates tests and manifest shasum.
> 
> - **Validation (`packages/snap/src/core/handlers/onClientRequest/validation.ts`)**
>   - Remove 1-minute timestamp window check in `parseRewardsMessage`/`RewardsMessageStruct`.
>   - Enforce timestamp is a positive integer (no decimals, > 0); unify errors to `Invalid timestamp`/`Invalid timestamp format`.
>   - Update docstring to require a valid timestamp (not time-window bound).
> - **Tests (`packages/snap/src/core/handlers/onClientRequest/validation.test.ts`)**
>   - Expect `Invalid timestamp` for malformed/invalid timestamps.
>   - Remove tests for 1-minute window rejection and boundary acceptance.
> - **Manifest (`packages/snap/snap.manifest.json`)**
>   - Update `source.shasum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92c22855d0f59dd94050a3c1777ce526850b9f80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->