### PR TITLE
fix: enable devnet only for flask

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' --check",
     "lint:types": "tsc --noEmit",
-    "start": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop  --port 3000"
+    "start": "GATSBY_TELEMETRY_DISABLED=1 NODE_ENV=development gatsby develop  --port 3000"
   },
   "browserslist": {
     "production": [

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "oEzBG5pOyRPcnnku0Dh518OFbLBslda0v/aI92Dz3+A=",
+    "shasum": "KIaSSSF6Gg9H1pzv1z19q+CNq1z0/5maXTvwvco0TOg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "kgBC7XoEcEFmck7TkIT+xzhp1nfw/diqTIqo6dXSE4s=",
+    "shasum": "oEzBG5pOyRPcnnku0Dh518OFbLBslda0v/aI92Dz3+A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -16,7 +16,9 @@
         "registry": "https://registry.npmjs.org/"
       }
     },
-    "locales": ["locales/en.json"]
+    "locales": [
+      "locales/en.json"
+    ]
   },
   "initialConnections": {
     "https://portfolio.metamask.io": {}
@@ -27,16 +29,23 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": ["https://portfolio.metamask.io"]
+      "allowedOrigins": [
+        "https://portfolio.metamask.io"
+      ]
     },
     "snap_getBip32Entropy": [
       {
-        "path": ["m", "44'", "501'"],
+        "path": [
+          "m",
+          "44'",
+          "501'"
+        ],
         "curve": "ed25519"
       }
     ],
     "endowment:lifecycle-hooks": {},
     "endowment:network-access": {},
+    "endowment:ethereum-provider": {},
     "endowment:cronjob": {
       "jobs": []
     },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "KIaSSSF6Gg9H1pzv1z19q+CNq1z0/5maXTvwvco0TOg=",
+    "shasum": "fR8JIQPPKK6QqODwkOeksbdHXGJhw1eRwLLMT68Cs1Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -16,9 +16,7 @@
         "registry": "https://registry.npmjs.org/"
       }
     },
-    "locales": [
-      "locales/en.json"
-    ]
+    "locales": ["locales/en.json"]
   },
   "initialConnections": {
     "https://portfolio.metamask.io": {}
@@ -29,17 +27,11 @@
       "snaps": false
     },
     "endowment:keyring": {
-      "allowedOrigins": [
-        "https://portfolio.metamask.io"
-      ]
+      "allowedOrigins": ["https://portfolio.metamask.io"]
     },
     "snap_getBip32Entropy": [
       {
-        "path": [
-          "m",
-          "44'",
-          "501'"
-        ],
+        "path": ["m", "44'", "501'"],
         "curve": "ed25519"
       }
     ],

--- a/packages/snap/src/core/services/assets/AssetsService.test.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.test.ts
@@ -47,9 +47,7 @@ describe('AssetsService', () => {
     mockConnection = createMockConnection();
 
     mockConfigProvider = {
-      get: jest.fn().mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      }),
+      getActiveNetworks: jest.fn().mockResolvedValue([Network.Mainnet]),
     } as unknown as ConfigProvider;
 
     mockTokenApiClient = {

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -80,8 +80,6 @@ export class AssetsService {
 
   readonly #nftApiClient: NftApiClient;
 
-  readonly #activeNetworks: Network[];
-
   public static readonly cacheTtlsMilliseconds = {
     tokenAccountsByOwner: 5 * Duration.Second,
   };
@@ -113,7 +111,6 @@ export class AssetsService {
     this.#tokenPricesService = tokenPricesService;
     this.#cache = cache;
     this.#nftApiClient = nftApiClient;
-    this.#activeNetworks = configProvider.get().activeNetworks;
   }
 
   #splitAssetsByType(assetTypes: CaipAssetType[]) {
@@ -345,7 +342,7 @@ export class AssetsService {
       this.#fetchTokenAccountsMultiple(
         [account],
         [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS],
-        this.#activeNetworks,
+        await this.#configProvider.getActiveNetworks(),
       ),
     ]);
 
@@ -387,8 +384,9 @@ export class AssetsService {
     ];
   }
 
-  getNativeAssetTypes(): NativeCaipAssetType[] {
-    return this.#activeNetworks.map(
+  async getNativeAssetTypes(): Promise<NativeCaipAssetType[]> {
+    const activeNetworks = await this.#configProvider.getActiveNetworks();
+    return activeNetworks.map(
       (network) => `${network}/${SolanaCaip19Tokens.SOL}` as const,
     );
   }
@@ -396,7 +394,7 @@ export class AssetsService {
   async #fetchNativeAssets(
     account: SolanaKeyringAccount,
   ): Promise<NativeAsset[]> {
-    const nativeAssetsTypes = this.getNativeAssetTypes();
+    const nativeAssetsTypes = await this.getNativeAssetTypes();
 
     const accountAddress = asAddress(account.address);
 
@@ -650,7 +648,7 @@ export class AssetsService {
       await this.#assetsRepository.findByKeyringAccountId(keyringAccountId);
 
     // Every account must have at least the native assets. Ensure that they are always present, even if not yet fetched/saved.
-    const nativeAssetTypes = this.getNativeAssetTypes();
+    const nativeAssetTypes = await this.getNativeAssetTypes();
     const missingNativeAssets: NativeAsset[] = [];
 
     for (const nativeAssetType of nativeAssetTypes) {

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -243,8 +243,10 @@ export class ConfigProvider {
       return this.#activeNetworks;
     }
 
-    const baseNetworks =
-      ENVIRONMENT_TO_ACTIVE_NETWORKS[this.#config.environment] ?? [];
+    const baseNetworks = uniq([
+      Network.Mainnet,
+      ...(ENVIRONMENT_TO_ACTIVE_NETWORKS[this.#config.environment] ?? []),
+    ]);
 
     try {
       // Otherwise, fetch them from the client

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -13,10 +13,10 @@ import { Duration } from '@metamask/utils';
 import { Network, Networks } from '../../constants/solana';
 import { UrlStruct } from '../../validation/structs';
 
-const ENVIRONMENT_TO_ACTIVE_NETWORKS = {
-  production: [Network.Mainnet, Network.Devnet],
-  local: [Network.Mainnet, Network.Devnet],
-  test: [Network.Localnet, Network.Devnet],
+const ENVIRONMENT_TO_ACTIVE_NETWORKS: Record<string, Network[]> = {
+  production: [Network.Mainnet],
+  local: [Network.Mainnet],
+  test: [Network.Localnet],
 };
 
 const CommaSeparatedListOfUrlsStruct = coerce(
@@ -111,9 +111,12 @@ export type Config = {
 export class ConfigProvider {
   #config: Config;
 
+  #activeNetworks: Network[];
+
   constructor() {
     const environment = this.#parseEnvironment();
     this.#config = this.#buildConfig(environment);
+    this.#activeNetworks = [];
   }
 
   #parseEnvironment() {
@@ -167,7 +170,7 @@ export class ConfigProvider {
         },
       ],
       explorerBaseUrl: environment.EXPLORER_BASE_URL,
-      activeNetworks: ENVIRONMENT_TO_ACTIVE_NETWORKS[environment.ENVIRONMENT],
+      activeNetworks: [],
       priceApi: {
         baseUrl:
           environment.ENVIRONMENT === 'test'
@@ -231,5 +234,29 @@ export class ConfigProvider {
       throw new Error(`Network ${key} not found`);
     }
     return network;
+  }
+
+  async setActiveNetworks(): Promise<Network[]> {
+    // If the active networks are already set, return them
+    if (this.#activeNetworks.length > 0) {
+      return this.#activeNetworks;
+    }
+
+    // Otherwise, fetch them from the client
+    const clientVersion = await ethereum.request({
+      method: 'web3_clientVersion',
+    });
+    const isFlask = (clientVersion as string)?.includes('flask');
+    const activeNetworks = ENVIRONMENT_TO_ACTIVE_NETWORKS[
+      this.#config.environment
+    ] as Network[];
+
+    if (activeNetworks && isFlask) {
+      activeNetworks.push(Network.Devnet);
+    }
+
+    // Set the active networks
+    this.#activeNetworks = activeNetworks ?? [];
+    return this.#activeNetworks;
   }
 }

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -13,6 +13,8 @@ import { Duration } from '@metamask/utils';
 import { Network, Networks } from '../../constants/solana';
 import { UrlStruct } from '../../validation/structs';
 
+export const SUPPORTED_NETWORKS = [Network.Mainnet, Network.Devnet];
+
 const ENVIRONMENT_TO_ACTIVE_NETWORKS: Record<string, Network[]> = {
   production: [Network.Mainnet],
   local: [Network.Mainnet],
@@ -60,7 +62,6 @@ export type NetworkConfig = (typeof Networks)[Network] & {
 export type Config = {
   environment: string;
   networks: NetworkConfig[];
-  activeNetworks: Network[];
   explorerBaseUrl: string;
   priceApi: {
     baseUrl: string;
@@ -170,7 +171,6 @@ export class ConfigProvider {
         },
       ],
       explorerBaseUrl: environment.EXPLORER_BASE_URL,
-      activeNetworks: [],
       priceApi: {
         baseUrl:
           environment.ENVIRONMENT === 'test'
@@ -236,7 +236,7 @@ export class ConfigProvider {
     return network;
   }
 
-  async setActiveNetworks(): Promise<Network[]> {
+  async getActiveNetworks(): Promise<Network[]> {
     // If the active networks are already set, return them
     if (this.#activeNetworks.length > 0) {
       return this.#activeNetworks;

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -9,6 +9,7 @@ import {
   string,
 } from '@metamask/superstruct';
 import { Duration } from '@metamask/utils';
+import { uniq } from 'lodash';
 
 import { Network, Networks } from '../../constants/solana';
 import { UrlStruct } from '../../validation/structs';
@@ -247,13 +248,11 @@ export class ConfigProvider {
       method: 'web3_clientVersion',
     });
     const isFlask = (clientVersion as string)?.includes('flask');
-    const activeNetworks = ENVIRONMENT_TO_ACTIVE_NETWORKS[
-      this.#config.environment
-    ] as Network[];
+    const baseNetworks =
+      ENVIRONMENT_TO_ACTIVE_NETWORKS[this.#config.environment] ?? [];
+    const flaskNetworks = isFlask ? [Network.Devnet] : [];
 
-    if (activeNetworks && isFlask) {
-      activeNetworks.push(Network.Devnet);
-    }
+    const activeNetworks = uniq([...baseNetworks, ...flaskNetworks]);
 
     // Set the active networks
     this.#activeNetworks = activeNetworks ?? [];

--- a/packages/snap/src/core/services/config/ConfigProvider.ts
+++ b/packages/snap/src/core/services/config/ConfigProvider.ts
@@ -243,19 +243,24 @@ export class ConfigProvider {
       return this.#activeNetworks;
     }
 
-    // Otherwise, fetch them from the client
-    const clientVersion = await ethereum.request({
-      method: 'web3_clientVersion',
-    });
-    const isFlask = (clientVersion as string)?.includes('flask');
     const baseNetworks =
       ENVIRONMENT_TO_ACTIVE_NETWORKS[this.#config.environment] ?? [];
-    const flaskNetworks = isFlask ? [Network.Devnet] : [];
 
-    const activeNetworks = uniq([...baseNetworks, ...flaskNetworks]);
+    try {
+      // Otherwise, fetch them from the client
+      const clientVersion = await ethereum.request({
+        method: 'web3_clientVersion',
+      });
+      const isFlask = (clientVersion as string)?.includes('flask');
+      const flaskNetworks = isFlask ? [Network.Devnet] : [];
 
-    // Set the active networks
-    this.#activeNetworks = activeNetworks ?? [];
-    return this.#activeNetworks;
+      const activeNetworks = uniq([...baseNetworks, ...flaskNetworks]);
+
+      // Set the active networks
+      this.#activeNetworks = activeNetworks;
+      return this.#activeNetworks;
+    } catch (error) {
+      return baseNetworks;
+    }
   }
 }

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
@@ -100,9 +100,9 @@ describe('KeyringAccountMonitor', () => {
     } as unknown as TokenHelper;
 
     mockConfigProvider = {
-      get: jest.fn().mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      }),
+      getActiveNetworks: jest
+        .fn()
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]),
     } as unknown as ConfigProvider;
 
     mockEventEmitter = new EventEmitter(mockLogger);
@@ -214,9 +214,9 @@ describe('KeyringAccountMonitor', () => {
   describe('monitorKeyringAccount', () => {
     it('monitors the account native and token assets', async () => {
       // Setup 2 active networks
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       await keyringAccountMonitor.monitorKeyringAccount(account);
 
@@ -235,9 +235,9 @@ describe('KeyringAccountMonitor', () => {
         scopes: [Network.Mainnet], // Only mainnet, not devnet
       };
 
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       await keyringAccountMonitor.monitorKeyringAccount(
         accountWithLimitedScopes,
@@ -249,9 +249,9 @@ describe('KeyringAccountMonitor', () => {
 
     it("does not monitor an account on an active network that is not in the account's scopes", async () => {
       // Setup 1 active network
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet]);
 
       const accountWithDifferentScopes = {
         ...account,
@@ -267,9 +267,9 @@ describe('KeyringAccountMonitor', () => {
 
     it('does not monitor an account that is already monitored', async () => {
       // Setup 1 active network
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet]);
 
       // Try to monitor the same account twice
       await keyringAccountMonitor.monitorKeyringAccount(account);
@@ -282,9 +282,9 @@ describe('KeyringAccountMonitor', () => {
   describe('stopMonitorKeyringAccount', () => {
     it('stops monitoring the account native and token assets on all active networks', async () => {
       // Setup 2 active networks
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       await keyringAccountMonitor.monitorKeyringAccount(account);
 
@@ -306,9 +306,9 @@ describe('KeyringAccountMonitor', () => {
 
     beforeEach(() => {
       // Setup 1 active network for simplicity
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet]);
 
       jest
         .spyOn(mockTransactionsService, 'fetchLatestSignatures')

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
@@ -23,6 +23,7 @@ import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
 import type { AssetsService, TokenHelper } from '../assets';
 import type { ConfigProvider } from '../config';
+import { SUPPORTED_NETWORKS } from '../config/ConfigProvider';
 import type { TransactionsService } from '../transactions';
 import { isSpam } from '../transactions/utils/isSpam';
 
@@ -106,10 +107,8 @@ export class KeyringAccountMonitor {
     this.#eventEmitter.on('onUpdate', this.#handleOnStart.bind(this));
     this.#eventEmitter.on('onInstall', this.#handleOnStart.bind(this));
 
-    const { activeNetworks } = this.#configProvider.get();
-
     // Register callbacks that will handle account and program notifications.
-    activeNetworks.forEach((network) => {
+    SUPPORTED_NETWORKS.forEach((network) => {
       this.#subscriptionService.registerNotificationHandler(
         'accountSubscribe',
         network,
@@ -123,7 +122,7 @@ export class KeyringAccountMonitor {
     });
 
     // Register the connection recovery callback that will handle missed messages.
-    activeNetworks.forEach((network) => {
+    SUPPORTED_NETWORKS.forEach((network) => {
       this.#subscriptionService.registerConnectionRecoveryHandler(
         network,
         this.#handleConnectionRecovery.bind(this),
@@ -166,7 +165,7 @@ export class KeyringAccountMonitor {
       this.#logger.log('Monitoring keyring account', account);
 
       const { id } = account;
-      const { activeNetworks } = this.#configProvider.get();
+      const activeNetworks = await this.#configProvider.getActiveNetworks();
 
       if (this.#monitoredKeyringAccounts.has(id)) {
         this.#logger.log('Account is already being monitored', account);

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
@@ -90,9 +90,7 @@ describe('SignatureMonitor', () => {
     } as unknown as SolanaConnection;
 
     mockConfigProvider = {
-      get: jest.fn().mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      } as unknown as Config),
+      getActiveNetworks: jest.fn().mockReturnValue([Network.Mainnet]),
     } as unknown as ConfigProvider;
 
     signatureMonitor = new SignatureMonitor(

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
@@ -15,6 +15,7 @@ import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { AccountsService } from '../accounts/AccountsService';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { ConfigProvider } from '../config';
+import { SUPPORTED_NETWORKS } from '../config/ConfigProvider';
 import type { SolanaConnection } from '../connection';
 import type { TransactionsService } from '../transactions';
 import type { SubscriptionService } from './SubscriptionService';
@@ -65,9 +66,7 @@ export class SignatureMonitor {
   }
 
   #bindHandlers(): void {
-    const { activeNetworks } = this.#configProvider.get();
-
-    activeNetworks.forEach((network) => {
+    SUPPORTED_NETWORKS.forEach((network) => {
       this.#subscriptionService.registerNotificationHandler(
         'signatureSubscribe',
         network,

--- a/packages/snap/src/core/services/subscriptions/SubscriptionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/SubscriptionService.test.ts
@@ -168,9 +168,9 @@ describe('SubscriptionService', () => {
     } as unknown as SubscriptionRepository;
 
     mockConfigProvider = {
-      get: jest.fn().mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      }),
+      getActiveNetworks: jest
+        .fn()
+        .mockReturnValue([Network.Mainnet, Network.Devnet]),
     } as unknown as ConfigProvider;
 
     mockEventEmitter = new EventEmitter(mockLogger);

--- a/packages/snap/src/core/services/subscriptions/SubscriptionService.ts
+++ b/packages/snap/src/core/services/subscriptions/SubscriptionService.ts
@@ -17,6 +17,7 @@ import type { EventEmitter } from '../../../infrastructure';
 import type { Network } from '../../constants/solana';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { ConfigProvider } from '../config';
+import { SUPPORTED_NETWORKS } from '../config/ConfigProvider';
 import { parseWebSocketMessage } from './parseWebSocketMessage';
 import type { SubscriptionRepository } from './SubscriptionRepository';
 import type { WebSocketConnectionService } from './WebSocketConnectionService';
@@ -80,8 +81,8 @@ export class SubscriptionService {
      * - The connection was lost then re-established -> we need to re-subscribe.
      * - The connection was not yet established, and we need to subscribe when it is established.
      */
-    const { activeNetworks } = this.#configProvider.get();
-    activeNetworks.forEach((network) => {
+
+    SUPPORTED_NETWORKS.forEach((network) => {
       this.#connectionService.onConnectionRecovery(
         network,
         this.#reSubscribe.bind(this),

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -157,9 +157,9 @@ describe('WebSocketConnectionService', () => {
 
   describe('#openConnectionsForActiveNetworks', () => {
     it('opens the connections for all active networks', async () => {
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       jest.spyOn(service, 'openConnection').mockResolvedValueOnce(undefined);
 
@@ -181,9 +181,9 @@ describe('WebSocketConnectionService', () => {
        * - upon opening, we will trigger all recovery handlers
        * - but since retry attempts have been cleared, they should not have been called
        */
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet]);
       jest
         .spyOn(mockWebSocketConnectionRepository, 'getAll')
         .mockResolvedValueOnce([]);

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -77,13 +77,15 @@ describe('WebSocketConnectionService', () => {
     mockConfigProvider = {
       get: jest.fn().mockReturnValue({
         networks: mockNetworksConfig,
-        activeNetworks: [Network.Mainnet, Network.Devnet],
         subscriptions: {
           maxReconnectAttempts: 5,
           reconnectDelayMilliseconds: 1, // To speed up the tests
           closeConnectionsGracePeriodMilliseconds: 5000, // 5 seconds for testing
         },
       }),
+      getActiveNetworks: jest
+        .fn()
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]),
       getNetworkBy: jest.fn().mockImplementation((key, value) => {
         return mockNetworksConfig.find(
           (item) => item[key as keyof NetworkConfig] === value,
@@ -107,9 +109,9 @@ describe('WebSocketConnectionService', () => {
 
   describe('#setupConnections', () => {
     it('opens the connections for all active networks when the client is active', async () => {
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       jest.spyOn(snap, 'request').mockResolvedValueOnce({
         active: true,
@@ -122,9 +124,9 @@ describe('WebSocketConnectionService', () => {
     });
 
     it('closes the connections for all active networks when the client is inactive', async () => {
-      jest.spyOn(mockConfigProvider, 'get').mockReturnValue({
-        activeNetworks: [Network.Mainnet, Network.Devnet],
-      } as unknown as Config);
+      jest
+        .spyOn(mockConfigProvider, 'getActiveNetworks')
+        .mockResolvedValue([Network.Mainnet, Network.Devnet]);
 
       jest.spyOn(snap, 'request').mockResolvedValueOnce({
         active: false,

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -135,7 +135,7 @@ export class WebSocketConnectionService {
   async #openConnectionsForActiveNetworks(): Promise<void> {
     this.#logger.log(`Opening connections for active networks`);
 
-    const { activeNetworks } = this.#configProvider.get();
+    const activeNetworks = await this.#configProvider.getActiveNetworks();
 
     this.#retryAttempts.clear();
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -48,6 +48,7 @@ import { eventHandlers as transactionConfirmationEvents } from './features/send/
 import { installPolyfills } from './polyfills';
 import snapContext, {
   clientRequestHandler,
+  configProvider,
   eventEmitter,
   keyring,
 } from './snapContext';
@@ -269,16 +270,19 @@ export const onWebSocketEvent: OnWebSocketEventHandler = async ({ event }) =>
 
 export const onStart: OnStartHandler = async () =>
   withCatchAndThrowSnapError(async () => {
+    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onStart');
   });
 
 export const onUpdate: OnUpdateHandler = async () =>
   withCatchAndThrowSnapError(async () => {
+    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onUpdate');
   });
 
 export const onInstall: OnInstallHandler = async () =>
   withCatchAndThrowSnapError(async () => {
+    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onInstall');
   });
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -48,7 +48,6 @@ import { eventHandlers as transactionConfirmationEvents } from './features/send/
 import { installPolyfills } from './polyfills';
 import snapContext, {
   clientRequestHandler,
-  configProvider,
   eventEmitter,
   keyring,
 } from './snapContext';

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -270,19 +270,16 @@ export const onWebSocketEvent: OnWebSocketEventHandler = async ({ event }) =>
 
 export const onStart: OnStartHandler = async () =>
   withCatchAndThrowSnapError(async () => {
-    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onStart');
   });
 
 export const onUpdate: OnUpdateHandler = async () =>
   withCatchAndThrowSnapError(async () => {
-    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onUpdate');
   });
 
 export const onInstall: OnInstallHandler = async () =>
   withCatchAndThrowSnapError(async () => {
-    await configProvider.setActiveNetworks();
     await eventEmitter.emitSync('onInstall');
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Dynamically resolves active networks (enabling Devnet only on Flask), updates services to use async network selection, adds ethereum-provider permission, and adjusts tests plus a minor dev script tweak.
> 
> - **Config**:
>   - Introduce `SUPPORTED_NETWORKS` and async `ConfigProvider.getActiveNetworks()`; remove `activeNetworks` from `Config`.
>   - Change `ENVIRONMENT_TO_ACTIVE_NETWORKS` (prod/local → Mainnet only; test → Localnet) and detect Flask via `web3_clientVersion` using `ethereum` provider; cache result.
> - **Services**:
>   - Assets/Subscriptions/WebSockets now use `getActiveNetworks()` (async) instead of `config.get().activeNetworks`.
>   - Register notification/recovery handlers against `SUPPORTED_NETWORKS`.
>   - `AssetsService`: remove cached `#activeNetworks`, make `getNativeAssetTypes()` async.
> - **Manifest**:
>   - Add `endowment:ethereum-provider` and update `source.shasum` in `packages/snap/snap.manifest.json`.
> - **Tests**:
>   - Update mocks to use `getActiveNetworks()` and `SUPPORTED_NETWORKS` expectations.
> - **Dev**:
>   - Set `NODE_ENV=development` in `packages/site/package.json` `start` script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26cb97ae877dbddb070af31fc6d1ec5bc79692e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->