### PR TITLE
fix: gracefully handle dismissed interface errors in background jobs

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Gracefully handle dismissed interface errors in background jobs ([#589](https://github.com/MetaMask/snap-solana-wallet/pull/589))
+
 ## [2.7.3]
 
 ### Fixed

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "uxQXMNTHd5uI4G7IKNaKQ+KA6ZA22i3y1Y4kELIws84=",
+    "shasum": "HuDgzNd9vOJrTgNNWV/i32P8KB96pWUOtZxGeKSQGaU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -12,6 +12,21 @@ import {
 } from '../../../utils/interface';
 import baseLogger, { createPrefixedLogger } from '../../../utils/logger';
 
+async function deleteInterfaceIdIfCurrent(interfaceId: string) {
+  const currentMap =
+    (await state.getKey<UnencryptedStateValue['mapInterfaceNameToId']>(
+      'mapInterfaceNameToId',
+    )) ?? {};
+  if (
+    currentMap[CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME] ===
+    interfaceId
+  ) {
+    await state.deleteKey(
+      `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
+    );
+  }
+}
+
 export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
   const logger = createPrefixedLogger(
     baseLogger,
@@ -42,9 +57,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
 
   if (!interfaceContext) {
     logger.info(`Interface context no longer exists, cleaning up state`);
-    await state.deleteKey(
-      `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
-    );
+    await deleteInterfaceIdIfCurrent(confirmationInterfaceId);
     return;
   }
 
@@ -71,13 +84,19 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       scanFetchStatus: 'fetching',
     } as ConfirmTransactionRequestContext;
 
-    await updateInterfaceIfExists(
+    const fetchingUpdated = await updateInterfaceIfExists(
       confirmationInterfaceId,
       <ConfirmTransactionRequest
         context={serialize(fetchingConfirmationContext) as any}
       />,
       fetchingConfirmationContext,
     );
+
+    if (!fetchingUpdated) {
+      logger.info(`Interface dismissed, cleaning up state`);
+      await deleteInterfaceIdIfCurrent(confirmationInterfaceId);
+      return;
+    }
 
     const [scan, updatedInterfaceContextFinal] = await Promise.all([
       transactionScanService.scanTransaction({
@@ -98,9 +117,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       logger.info(
         `Interface context no longer exists after scan, cleaning up state`,
       );
-      await state.deleteKey(
-        `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
-      );
+      await deleteInterfaceIdIfCurrent(confirmationInterfaceId);
       return;
     }
 
@@ -112,13 +129,19 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     };
     logger.info(`New scan fetched`);
 
-    await updateInterfaceIfExists(
+    const scanUpdated = await updateInterfaceIfExists(
       confirmationInterfaceId,
       <ConfirmTransactionRequest
         context={serialize(updatedInterfaceContext) as any}
       />,
       updatedInterfaceContext,
     );
+
+    if (!scanUpdated) {
+      logger.info(`Interface dismissed after scan, cleaning up state`);
+      await deleteInterfaceIdIfCurrent(confirmationInterfaceId);
+      return;
+    }
 
     logger.info(`Background event suceeded`);
 
@@ -139,9 +162,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
 
     if (!fetchedInterfaceContext) {
       logger.info(`Interface context no longer exists, cleaning up state`);
-      await state.deleteKey(
-        `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
-      );
+      await deleteInterfaceIdIfCurrent(confirmationInterfaceId);
       return;
     }
 

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -7,8 +7,8 @@ import { serialize } from '../../../serialization/serialize';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
   CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME,
-  getInterfaceContext,
-  updateInterface,
+  getInterfaceContextIfExists,
+  updateInterfaceIfExists,
 } from '../../../utils/interface';
 import baseLogger, { createPrefixedLogger } from '../../../utils/logger';
 
@@ -36,12 +36,15 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
 
   // Check if context exists in case the UI was closed before the background event ran
   const interfaceContext =
-    await getInterfaceContext<ConfirmTransactionRequestContext>(
+    await getInterfaceContextIfExists<ConfirmTransactionRequestContext>(
       confirmationInterfaceId,
     );
 
   if (!interfaceContext) {
-    logger.info(`Interface context no longer exists, skipping refresh`);
+    logger.info(`Interface context no longer exists, cleaning up state`);
+    await state.deleteKey(
+      `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
+    );
     return;
   }
 
@@ -68,7 +71,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       scanFetchStatus: 'fetching',
     } as ConfirmTransactionRequestContext;
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       confirmationInterfaceId,
       <ConfirmTransactionRequest
         context={serialize(fetchingConfirmationContext) as any}
@@ -85,7 +88,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
         origin: interfaceContext.origin,
         account: interfaceContext.account,
       }),
-      getInterfaceContext<ConfirmTransactionRequestContext>(
+      getInterfaceContextIfExists<ConfirmTransactionRequestContext>(
         confirmationInterfaceId,
       ),
     ]);
@@ -93,7 +96,10 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     // Check if context exists in case the UI was closed while scanning
     if (!updatedInterfaceContextFinal) {
       logger.info(
-        `Interface context no longer exists after scan, skipping update`,
+        `Interface context no longer exists after scan, cleaning up state`,
+      );
+      await state.deleteKey(
+        `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
       );
       return;
     }
@@ -106,7 +112,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
     };
     logger.info(`New scan fetched`);
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       confirmationInterfaceId,
       <ConfirmTransactionRequest
         context={serialize(updatedInterfaceContext) as any}
@@ -127,12 +133,15 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
   } catch (error) {
     // Check if context exists in case the UI was closed, nothing to rollback
     const fetchedInterfaceContext =
-      await getInterfaceContext<ConfirmTransactionRequestContext>(
+      await getInterfaceContextIfExists<ConfirmTransactionRequestContext>(
         confirmationInterfaceId,
       );
 
     if (!fetchedInterfaceContext) {
-      logger.info(`Interface context no longer exists, skipping rollback`);
+      logger.info(`Interface context no longer exists, cleaning up state`);
+      await state.deleteKey(
+        `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,
+      );
       return;
     }
 
@@ -141,7 +150,7 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       scanFetchStatus: 'fetched',
     } as ConfirmTransactionRequestContext;
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       confirmationInterfaceId,
       <ConfirmTransactionRequest
         context={serialize(fetchingConfirmationContext) as any}

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
@@ -6,10 +6,10 @@ import type { SendContext } from '../../../../features/send/types';
 import { assetsService, priceApiClient, state } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
 import {
-  getInterfaceContext,
+  getInterfaceContextIfExists,
   getPreferences,
   SEND_FORM_INTERFACE_NAME,
-  updateInterface,
+  updateInterfaceIfExists,
 } from '../../../utils/interface';
 import baseLogger, { createPrefixedLogger } from '../../../utils/logger';
 
@@ -38,10 +38,11 @@ export const refreshSend: OnCronjobHandler = async () => {
 
   // Check if context exists in case the UI was closed before the background event ran
   const interfaceContext =
-    await getInterfaceContext<SendContext>(sendFormInterfaceId);
+    await getInterfaceContextIfExists<SendContext>(sendFormInterfaceId);
 
   if (!interfaceContext) {
-    logger.info(`Interface context no longer exists, skipping refresh`);
+    logger.info(`Interface context no longer exists, cleaning up state`);
+    await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
     return;
   }
 
@@ -57,12 +58,13 @@ export const refreshSend: OnCronjobHandler = async () => {
 
     // Check if context exists in case the UI was closed while fetching prices
     const latestInterfaceContext =
-      await getInterfaceContext<SendContext>(sendFormInterfaceId);
+      await getInterfaceContextIfExists<SendContext>(sendFormInterfaceId);
 
     if (!latestInterfaceContext) {
       logger.info(
-        `Interface context no longer exists after fetching prices, skipping update`,
+        `Interface context no longer exists after fetching prices, cleaning up state`,
       );
+      await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
       return;
     }
 
@@ -75,7 +77,7 @@ export const refreshSend: OnCronjobHandler = async () => {
       },
     };
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       sendFormInterfaceId,
       <Send context={updatedInterfaceContext} />,
       updatedInterfaceContext,

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
@@ -13,6 +13,16 @@ import {
 } from '../../../utils/interface';
 import baseLogger, { createPrefixedLogger } from '../../../utils/logger';
 
+async function deleteInterfaceIdIfCurrent(interfaceId: string) {
+  const currentMap =
+    (await state.getKey<UnencryptedStateValue['mapInterfaceNameToId']>(
+      'mapInterfaceNameToId',
+    )) ?? {};
+  if (currentMap[SEND_FORM_INTERFACE_NAME] === interfaceId) {
+    await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
+  }
+}
+
 export const refreshSend: OnCronjobHandler = async () => {
   const logger = createPrefixedLogger(baseLogger, '[refreshSend]');
 
@@ -42,7 +52,7 @@ export const refreshSend: OnCronjobHandler = async () => {
 
   if (!interfaceContext) {
     logger.info(`Interface context no longer exists, cleaning up state`);
-    await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
+    await deleteInterfaceIdIfCurrent(sendFormInterfaceId);
     return;
   }
 
@@ -64,7 +74,7 @@ export const refreshSend: OnCronjobHandler = async () => {
       logger.info(
         `Interface context no longer exists after fetching prices, cleaning up state`,
       );
-      await state.deleteKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`);
+      await deleteInterfaceIdIfCurrent(sendFormInterfaceId);
       return;
     }
 
@@ -77,13 +87,19 @@ export const refreshSend: OnCronjobHandler = async () => {
       },
     };
 
-    await updateInterfaceIfExists(
+    const updated = await updateInterfaceIfExists(
       sendFormInterfaceId,
       <Send context={updatedInterfaceContext} />,
       updatedInterfaceContext,
     );
 
-    logger.info(`✅ Background event suceeded`);
+    if (!updated) {
+      logger.info(`Interface dismissed, cleaning up state`);
+      await deleteInterfaceIdIfCurrent(sendFormInterfaceId);
+      return;
+    }
+
+    logger.info(`Background event suceeded`);
 
     // Schedule the next run
     await snap.request({

--- a/packages/snap/src/core/utils/interface.test.ts
+++ b/packages/snap/src/core/utils/interface.test.ts
@@ -1,0 +1,158 @@
+import { expect } from '@jest/globals';
+
+import {
+  getInterfaceContextIfExists,
+  isInterfaceNotFoundError,
+  updateInterfaceIfExists,
+} from './interface';
+
+// Mock the snap global
+const mockSnapRequest = jest.fn();
+
+Object.defineProperty(globalThis, 'snap', {
+  value: {
+    request: mockSnapRequest,
+  },
+  writable: true,
+});
+
+describe('interface utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isInterfaceNotFoundError', () => {
+    it('returns true for interface not found error', () => {
+      const error = new Error("Interface with id 'abc123' not found.");
+      expect(isInterfaceNotFoundError(error)).toBe(true);
+    });
+
+    it('returns true for interface not found error (case insensitive)', () => {
+      const error = new Error("INTERFACE with id 'abc123' NOT FOUND.");
+      expect(isInterfaceNotFoundError(error)).toBe(true);
+    });
+
+    it('returns false for other errors', () => {
+      const error = new Error('Network timeout');
+      expect(isInterfaceNotFoundError(error)).toBe(false);
+    });
+
+    it('returns false for non-Error objects', () => {
+      expect(isInterfaceNotFoundError('string error')).toBe(false);
+      expect(isInterfaceNotFoundError(null)).toBe(false);
+      expect(isInterfaceNotFoundError(undefined)).toBe(false);
+      expect(isInterfaceNotFoundError({ message: 'interface not found' })).toBe(
+        false,
+      );
+    });
+
+    it('returns false for error with only "interface" in message', () => {
+      const error = new Error('Invalid interface configuration');
+      expect(isInterfaceNotFoundError(error)).toBe(false);
+    });
+
+    it('returns false for error with only "not found" in message', () => {
+      const error = new Error('Account not found');
+      expect(isInterfaceNotFoundError(error)).toBe(false);
+    });
+  });
+
+  describe('getInterfaceContextIfExists', () => {
+    it('returns context when interface exists', async () => {
+      const mockContext = { foo: 'bar', count: 42 };
+      mockSnapRequest.mockResolvedValue(mockContext);
+
+      const result = await getInterfaceContextIfExists<typeof mockContext>(
+        'test-interface-id',
+      );
+
+      expect(result).toStrictEqual(mockContext);
+      expect(mockSnapRequest).toHaveBeenCalledWith({
+        method: 'snap_getInterfaceContext',
+        params: { id: 'test-interface-id' },
+      });
+    });
+
+    it('returns null when rawContext is falsy', async () => {
+      mockSnapRequest.mockResolvedValue(null);
+
+      const result = await getInterfaceContextIfExists('test-interface-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when interface is not found', async () => {
+      mockSnapRequest.mockRejectedValue(
+        new Error("Interface with id 'test-interface-id' not found."),
+      );
+
+      const result = await getInterfaceContextIfExists('test-interface-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('re-throws non-interface-not-found errors', async () => {
+      const networkError = new Error('Network timeout');
+      mockSnapRequest.mockRejectedValue(networkError);
+
+      await expect(
+        getInterfaceContextIfExists('test-interface-id'),
+      ).rejects.toThrow('Network timeout');
+    });
+  });
+
+  describe('updateInterfaceIfExists', () => {
+    it('returns result when interface exists', async () => {
+      const mockResult = { success: true };
+      mockSnapRequest.mockResolvedValue(mockResult);
+
+      const mockUi = { type: 'Box', children: [] };
+      const mockContext = { foo: 'bar' };
+
+      const result = await updateInterfaceIfExists(
+        'test-interface-id',
+        mockUi as any,
+        mockContext,
+      );
+
+      expect(result).toStrictEqual(mockResult);
+      expect(mockSnapRequest).toHaveBeenCalledWith({
+        method: 'snap_updateInterface',
+        params: {
+          id: 'test-interface-id',
+          ui: mockUi,
+          context: mockContext,
+        },
+      });
+    });
+
+    it('returns null when interface is not found', async () => {
+      mockSnapRequest.mockRejectedValue(
+        new Error("Interface with id 'test-interface-id' not found."),
+      );
+
+      const mockUi = { type: 'Box', children: [] };
+      const mockContext = { foo: 'bar' };
+
+      const result = await updateInterfaceIfExists(
+        'test-interface-id',
+        mockUi as any,
+        mockContext,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('re-throws non-interface-not-found errors', async () => {
+      const networkError = new Error('Network timeout');
+      mockSnapRequest.mockRejectedValue(networkError);
+
+      const mockUi = { type: 'Box', children: [] };
+      const mockContext = { foo: 'bar' };
+
+      await expect(
+        updateInterfaceIfExists('test-interface-id', mockUi as any, mockContext),
+      ).rejects.toThrow('Network timeout');
+    });
+  });
+});

--- a/packages/snap/src/core/utils/interface.test.ts
+++ b/packages/snap/src/core/utils/interface.test.ts
@@ -62,9 +62,10 @@ describe('interface utilities', () => {
       const mockContext = { foo: 'bar', count: 42 };
       mockSnapRequest.mockResolvedValue(mockContext);
 
-      const result = await getInterfaceContextIfExists<typeof mockContext>(
-        'test-interface-id',
-      );
+      const result =
+        await getInterfaceContextIfExists<typeof mockContext>(
+          'test-interface-id',
+        );
 
       expect(result).toStrictEqual(mockContext);
       expect(mockSnapRequest).toHaveBeenCalledWith({
@@ -102,9 +103,8 @@ describe('interface utilities', () => {
   });
 
   describe('updateInterfaceIfExists', () => {
-    it('returns result when interface exists', async () => {
-      const mockResult = { success: true };
-      mockSnapRequest.mockResolvedValue(mockResult);
+    it('returns true when interface exists', async () => {
+      mockSnapRequest.mockResolvedValue(null);
 
       const mockUi = { type: 'Box', children: [] };
       const mockContext = { foo: 'bar' };
@@ -115,7 +115,7 @@ describe('interface utilities', () => {
         mockContext,
       );
 
-      expect(result).toStrictEqual(mockResult);
+      expect(result).toBe(true);
       expect(mockSnapRequest).toHaveBeenCalledWith({
         method: 'snap_updateInterface',
         params: {
@@ -151,7 +151,11 @@ describe('interface utilities', () => {
       const mockContext = { foo: 'bar' };
 
       await expect(
-        updateInterfaceIfExists('test-interface-id', mockUi as any, mockContext),
+        updateInterfaceIfExists(
+          'test-interface-id',
+          mockUi as any,
+          mockContext,
+        ),
       ).rejects.toThrow('Network timeout');
     });
   });

--- a/packages/snap/src/core/utils/interface.ts
+++ b/packages/snap/src/core/utils/interface.ts
@@ -22,6 +22,21 @@ export const CONFIRM_SIGN_MESSAGE_INTERFACE_NAME = 'confirm-sign-message';
 export const CONFIRM_SIGN_IN_INTERFACE_NAME = 'confirm-sign-in';
 
 /**
+ * Checks if an error is an "interface not found" error.
+ * This occurs when calling interface methods on a dismissed interface.
+ *
+ * @param error - The error to check.
+ * @returns True if the error indicates the interface was not found.
+ */
+export function isInterfaceNotFoundError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return message.includes('interface') && message.includes('not found');
+  }
+  return false;
+}
+
+/**
  * Creates an interface using the provided UI component and context.
  *
  * @param ui - The UI component or element.
@@ -64,6 +79,38 @@ export async function updateInterface<TContext extends Serializable>(
       context: serializedContext,
     },
   });
+}
+
+/**
+ * Updates an interface using the provided UI component and context.
+ * Returns null if the interface has been dismissed by the user.
+ *
+ * @param id - The ID for the interface to update.
+ * @param ui - The UI component or element.
+ * @param context - The context for the interface.
+ * @returns The update result, or null if the interface was not found.
+ */
+export async function updateInterfaceIfExists<TContext extends Serializable>(
+  id: string,
+  ui: ComponentOrElement,
+  context: TContext,
+): Promise<UpdateInterfaceResult | null> {
+  try {
+    const serializedContext = serialize(context);
+    return await snap.request({
+      method: 'snap_updateInterface',
+      params: {
+        id,
+        ui,
+        context: serializedContext,
+      },
+    });
+  } catch (error) {
+    if (isInterfaceNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -131,42 +178,33 @@ export async function getPreferences(): Promise<Preferences> {
 
 /**
  * Retrieves the context of an interactive interface by its ID.
+ * Returns null if the interface has been dismissed by the user.
  *
  * @param interfaceId - The ID for the interface to retrieve the context.
- * @returns An object containing the context of the interface.
+ * @returns The context object, or null if the interface was not found.
  */
-export async function getInterfaceContext<TContext extends Serializable>(
-  interfaceId: string,
-): Promise<TContext | null> {
-  const rawContext = await snap.request({
-    method: 'snap_getInterfaceContext',
-    params: {
-      id: interfaceId,
-    },
-  });
+export async function getInterfaceContextIfExists<
+  TContext extends Serializable,
+>(interfaceId: string): Promise<TContext | null> {
+  try {
+    const rawContext = await snap.request({
+      method: 'snap_getInterfaceContext',
+      params: {
+        id: interfaceId,
+      },
+    });
 
-  if (!rawContext) {
-    return null;
+    if (!rawContext) {
+      return null;
+    }
+
+    return deserialize(rawContext) as TContext;
+  } catch (error) {
+    if (isInterfaceNotFoundError(error)) {
+      return null;
+    }
+    throw error;
   }
-
-  return deserialize(rawContext) as TContext;
-}
-
-/**
- * Retrieves the context of an interactive interface by its ID.
- *
- * @param interfaceId - The ID for the interface to retrieve the context.
- * @returns An object containing the context of the interface.
- * @throws If the interface context is not found.
- */
-export async function getInterfaceContextOrThrow<TContext extends Serializable>(
-  interfaceId: string,
-): Promise<TContext> {
-  const context = await getInterfaceContext<TContext>(interfaceId);
-  if (!context) {
-    throw new Error('Interface context not found');
-  }
-  return context;
 }
 
 /**

--- a/packages/snap/src/core/utils/interface.ts
+++ b/packages/snap/src/core/utils/interface.ts
@@ -88,16 +88,16 @@ export async function updateInterface<TContext extends Serializable>(
  * @param id - The ID for the interface to update.
  * @param ui - The UI component or element.
  * @param context - The context for the interface.
- * @returns The update result, or null if the interface was not found.
+ * @returns True if the interface was updated, or null if it was not found.
  */
 export async function updateInterfaceIfExists<TContext extends Serializable>(
   id: string,
   ui: ComponentOrElement,
   context: TContext,
-): Promise<UpdateInterfaceResult | null> {
+): Promise<true | null> {
   try {
     const serializedContext = serialize(context);
-    return await snap.request({
+    await snap.request({
       method: 'snap_updateInterface',
       params: {
         id,
@@ -105,6 +105,7 @@ export async function updateInterfaceIfExists<TContext extends Serializable>(
         context: serializedContext,
       },
     });
+    return true;
   } catch (error) {
     if (isInterfaceNotFoundError(error)) {
       return null;

--- a/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
@@ -9,7 +9,7 @@ import {
   createInterface,
   getPreferences,
   showDialog,
-  updateInterface,
+  updateInterfaceIfExists,
 } from '../../../../core/utils/interface';
 import logger from '../../../../core/utils/logger';
 import { extractInstructionsFromUnknownBase64String } from '../../../../entities';
@@ -157,11 +157,15 @@ export async function render(
   }
   updatedContext1.feeEstimatedInSol = feeEstimatedInSol;
 
-  await updateInterface(
+  const updated1 = await updateInterfaceIfExists(
     id,
     <ConfirmTransactionRequest context={updatedContext1} />,
     updatedContext1,
   );
+
+  if (!updated1) {
+    return dialogPromise;
+  }
 
   /**
    * Third render:
@@ -206,11 +210,15 @@ export async function render(
     updatedContext2.scan = null;
   }
 
-  await updateInterface(
+  const updated2 = await updateInterfaceIfExists(
     id,
     <ConfirmTransactionRequest context={updatedContext2} />,
     updatedContext2,
   );
+
+  if (!updated2) {
+    return dialogPromise;
+  }
 
   await state.setKey(
     `mapInterfaceNameToId.${CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME}`,

--- a/packages/snap/src/features/send/render.tsx
+++ b/packages/snap/src/features/send/render.tsx
@@ -10,7 +10,7 @@ import {
   getPreferences,
   SEND_FORM_INTERFACE_NAME,
   showDialog,
-  updateInterface,
+  updateInterfaceIfExists,
 } from '../../core/utils/interface';
 import {
   accountsService,
@@ -159,7 +159,15 @@ export const renderSend: OnRpcRequestHandler = async ({ request }) => {
 
   context.loading = true;
 
-  await updateInterface(id, <Send context={context} />, context);
+  const localDataInterfaceUpdateSucceeded = await updateInterfaceIfExists(
+    id,
+    <Send context={context} />,
+    context,
+  );
+
+  if (!localDataInterfaceUpdateSucceeded) {
+    return dialogPromise;
+  }
 
   // eslint-disable-next-line require-atomic-updates
   context.loading = false;
@@ -175,7 +183,15 @@ export const renderSend: OnRpcRequestHandler = async ({ request }) => {
     minimumBalanceForRentExemptionPromise,
   ]);
 
-  await updateInterface(id, <Send context={context} />, context);
+  const apiDataInterfaceUpdateSucceeded = await updateInterfaceIfExists(
+    id,
+    <Send context={context} />,
+    context,
+  );
+
+  if (!apiDataInterfaceUpdateSucceeded) {
+    return dialogPromise;
+  }
 
   await state.setKey(`mapInterfaceNameToId.${SEND_FORM_INTERFACE_NAME}`, id);
 

--- a/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.test.tsx
+++ b/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.test.tsx
@@ -71,6 +71,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
       .getComputeUnitPriceMicroLamportsPerComputeUnit.mockReturnValue(10000n);
 
     (getInterfaceContextIfExists as jest.Mock).mockResolvedValue(mockContext);
+    (updateInterfaceIfExists as jest.Mock).mockResolvedValue(true);
   });
 
   describe('buildTransactionMessageAndUpdateInterface_INTERNAL', () => {

--- a/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.test.tsx
+++ b/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.test.tsx
@@ -7,8 +7,8 @@ import {
   MOCK_SOLANA_KEYRING_ACCOUNT_1,
 } from '../../../core/test/mocks/solana-keyring-accounts';
 import {
-  getInterfaceContext,
-  updateInterface,
+  getInterfaceContextIfExists,
+  updateInterfaceIfExists,
 } from '../../../core/utils/interface';
 import {
   keyring,
@@ -70,7 +70,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
       .mocked(sendSolBuilder)
       .getComputeUnitPriceMicroLamportsPerComputeUnit.mockReturnValue(10000n);
 
-    (getInterfaceContext as jest.Mock).mockResolvedValue(mockContext);
+    (getInterfaceContextIfExists as jest.Mock).mockResolvedValue(mockContext);
   });
 
   describe('buildTransactionMessageAndUpdateInterface_INTERNAL', () => {
@@ -82,7 +82,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
         mockContext,
       );
 
-      expect(updateInterface).not.toHaveBeenCalled();
+      expect(updateInterfaceIfExists).not.toHaveBeenCalled();
       expect(keyring.getAccountOrThrow).not.toHaveBeenCalled();
     });
 
@@ -98,7 +98,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
         amount: '1.0',
         network: Network.Testnet,
       });
-      expect(updateInterface).toHaveBeenCalledTimes(2);
+      expect(updateInterfaceIfExists).toHaveBeenCalledTimes(2);
     });
 
     it('builds SPL token transaction when tokenCaipId is not native token', async () => {
@@ -113,7 +113,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
       );
 
       expect(sendSplTokenBuilder.buildTransactionMessage).toHaveBeenCalled();
-      expect(updateInterface).toHaveBeenCalledTimes(2);
+      expect(updateInterfaceIfExists).toHaveBeenCalledTimes(2);
     });
 
     it('handles transaction build errors', async () => {
@@ -126,7 +126,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
         mockContext,
       );
 
-      expect(updateInterface).toHaveBeenCalledWith(
+      expect(updateInterfaceIfExists).toHaveBeenCalledWith(
         mockId,
         expect.anything(),
         expect.objectContaining({
@@ -145,7 +145,7 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
         mockContext,
       );
 
-      expect(updateInterface).toHaveBeenLastCalledWith(
+      expect(updateInterfaceIfExists).toHaveBeenLastCalledWith(
         mockId,
         expect.anything(),
         expect.objectContaining({
@@ -158,31 +158,31 @@ describe('buildTransactionMessageAndUpdateInterface', () => {
     });
 
     it('gracefully exits when interface context no longer exists after build', async () => {
-      // getInterfaceContext is called after build - returns null (interface closed)
-      (getInterfaceContext as jest.Mock).mockResolvedValueOnce(null);
+      // getInterfaceContextIfExists is called after build - returns null (interface closed)
+      (getInterfaceContextIfExists as jest.Mock).mockResolvedValueOnce(null);
 
       await buildTransactionMessageAndUpdateInterface_INTERNAL(
         mockId,
         mockContext,
       );
 
-      // Should only call updateInterface once (initial update), not the second time
-      expect(updateInterface).toHaveBeenCalledTimes(1);
+      // Should only call updateInterfaceIfExists once (initial update), not the second time
+      expect(updateInterfaceIfExists).toHaveBeenCalledTimes(1);
     });
 
     it('gracefully exits when interface context no longer exists after error', async () => {
       (sendSolBuilder.buildTransactionMessage as jest.Mock).mockRejectedValue(
         new Error('Build failed'),
       );
-      (getInterfaceContext as jest.Mock).mockResolvedValue(null);
+      (getInterfaceContextIfExists as jest.Mock).mockResolvedValue(null);
 
       await buildTransactionMessageAndUpdateInterface_INTERNAL(
         mockId,
         mockContext,
       );
 
-      // Should only call updateInterface once (initial update), not for error display
-      expect(updateInterface).toHaveBeenCalledTimes(1);
+      // Should only call updateInterfaceIfExists once (initial update), not for error display
+      expect(updateInterfaceIfExists).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.tsx
+++ b/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.tsx
@@ -91,11 +91,15 @@ export const buildTransactionMessageAndUpdateInterface_INTERNAL = async (
       feeEstimatedInSol: null,
     };
 
-    await updateInterfaceIfExists(
+    const initialUpdated = await updateInterfaceIfExists(
       interfaceId,
       <Send context={{ ...context, ...contextUpdatesInitial }} />,
       { ...context, ...contextUpdatesInitial },
     );
+
+    if (!initialUpdated) {
+      return;
+    }
 
     const { feeInLamports, base64EncodedTransactionMessage } =
       await buildTransactionMessage(context);

--- a/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.tsx
+++ b/packages/snap/src/features/send/utils/buildTransactionMessageAndUpdateInterface.tsx
@@ -9,8 +9,8 @@ import { SendFeeCalculator } from '../../../core/services';
 import { withoutConcurrency } from '../../../core/utils/concurrency';
 import { lamportsToSol } from '../../../core/utils/conversion';
 import {
-  getInterfaceContext,
-  updateInterface,
+  getInterfaceContextIfExists,
+  updateInterfaceIfExists,
 } from '../../../core/utils/interface';
 import logger from '../../../core/utils/logger';
 import {
@@ -91,7 +91,7 @@ export const buildTransactionMessageAndUpdateInterface_INTERNAL = async (
       feeEstimatedInSol: null,
     };
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       interfaceId,
       <Send context={{ ...context, ...contextUpdatesInitial }} />,
       { ...context, ...contextUpdatesInitial },
@@ -109,13 +109,14 @@ export const buildTransactionMessageAndUpdateInterface_INTERNAL = async (
     };
 
     // Check if context exists in case the UI was closed while building the transaction
-    const latestContext = await getInterfaceContext<SendContext>(interfaceId);
+    const latestContext =
+      await getInterfaceContextIfExists<SendContext>(interfaceId);
 
     if (!latestContext) {
       return;
     }
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       interfaceId,
       <Send context={{ ...latestContext, ...contextUpdatesAfterBuild }} />,
       { ...latestContext, ...contextUpdatesAfterBuild },
@@ -134,13 +135,14 @@ export const buildTransactionMessageAndUpdateInterface_INTERNAL = async (
     };
 
     // Check if context exists in case the UI was closed
-    const latestContext = await getInterfaceContext<SendContext>(interfaceId);
+    const latestContext =
+      await getInterfaceContextIfExists<SendContext>(interfaceId);
 
     if (!latestContext) {
       return;
     }
 
-    await updateInterface(
+    await updateInterfaceIfExists(
       interfaceId,
       <Send context={{ ...latestContext, ...contextUpdatesAfterError }} />,
       { ...latestContext, ...contextUpdatesAfterError },


### PR DESCRIPTION
## Summary

When users dismiss confirmation dialogs (click outside, press escape, or close them), background operations like price refreshes and security scans may still be running. These operations would try to update or read from the dismissed interface, causing noisy "Interface not found" errors in the logs.

This PR implements graceful error handling by adding `*IfExists` variants of interface methods that return `null` instead of throwing when an interface has been dismissed.

## Changes

### New Methods in `interface.ts`

| Method | Behavior | Use Case |
|--------|----------|----------|
| `isInterfaceNotFoundError(error)` | Detects "interface not found" errors | Error classification helper |
| `getInterfaceContextIfExists(id)` | Returns context or `null` if dismissed | Replaces `getInterfaceContext` |
| `updateInterfaceIfExists(id, ui, ctx)` | Returns result or `null` if dismissed | For background/async operations |

### Naming Convention

- Methods with `*IfExists` suffix explicitly indicate they swallow "interface not found" errors
- Original `updateInterface` is kept for event handlers where the interface **must** exist
- Removed unused `getInterfaceContextOrThrow` function

### Background Jobs Updated

- `refreshSend.tsx` - Token price refresh (every 30s)
- `refreshConfirmationEstimation.tsx` - Security scan refresh (every 20s)
- `buildTransactionMessageAndUpdateInterface.tsx` - Transaction building

These now:
1. Use `*IfExists` methods for defensive error handling
2. Clean up state (`mapInterfaceNameToId`) when interface is dismissed
3. Log informational messages instead of warnings for expected dismissals

## Test Plan

- [x] All core tests pass (`yarn test:core`)
- [x] All feature tests pass (`yarn test:features`)
- [x] New unit tests for `isInterfaceNotFoundError`, `getInterfaceContextIfExists`, and `updateInterfaceIfExists`
- [ ] Manual test: Open Send form, dismiss quickly during price refresh - no error logs
- [ ] Manual test: Open confirmation dialog, dismiss during security scan - no error logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared interface utilities and multiple async UI/background update paths; mistakes could cause silent UI non-updates or stale `mapInterfaceNameToId` entries, but changes are localized to handling dismissed interfaces.
> 
> **Overview**
> Prevents noisy "Interface not found" errors when users dismiss dialogs while async work is still running by adding `isInterfaceNotFoundError`, `getInterfaceContextIfExists`, and `updateInterfaceIfExists` to swallow dismissed-interface failures.
> 
> Updates the send and confirmation refresh cronjobs and related UI render/update flows to use the new `*IfExists` helpers, early-exit when the UI is gone, and proactively clean `mapInterfaceNameToId` state entries; includes new unit coverage for the interface helpers and a manifest `shasum`/changelog bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bcf508f97df80ec61aba0f8bc657bcab0277e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->