### PR TITLE
fix: emit Transaction Submitted event at broadcast time

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "E4+26+oeze+hKIhSlFKJ/7ohPOc9AzeZgOud18kur7g=",
+    "shasum": "krAMsU4HOfWoBt4BHP3zVDRnSfOyuShlVq1OluSAaBI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
@@ -148,7 +148,7 @@ describe('SignatureMonitor', () => {
   });
 
   describe('#handleSignatureNotification', () => {
-    it('when the tx is processed, it saves the transaction, tracks an event in analytics, and unsubscribes', async () => {
+    it('when the tx is processed, it saves the transaction and unsubscribes', async () => {
       const mockNotification = {} as unknown as SignatureNotification;
       const mockSubscription = {
         id: 'subscription-id-123',
@@ -182,10 +182,7 @@ describe('SignatureMonitor', () => {
 
       expect(
         mockAnalyticsService.trackEventTransactionSubmitted,
-      ).toHaveBeenCalledWith(mockAccount, signature, {
-        origin,
-        scope: network,
-      });
+      ).not.toHaveBeenCalled();
 
       expect(mockSubscriptionService.unsubscribe).toHaveBeenCalledWith(
         mockSubscription.id,

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
@@ -180,22 +180,11 @@ export class SignatureMonitor {
         );
       }
 
-      switch (commitment) {
-        case 'processed':
-          await this.#transactionsService.save(transaction);
-          await this.#analyticsService.trackEventTransactionSubmitted(
-            account,
-            signature,
-            {
-              scope: network,
-              origin,
-            },
-          );
+      await this.#transactionsService.save(transaction);
 
-          break;
+      switch (commitment) {
         case 'confirmed':
         case 'finalized':
-          await this.#transactionsService.save(transaction);
           await this.#analyticsService.trackEventTransactionFinalized(
             account,
             transaction,

--- a/packages/snap/src/core/services/wallet/WalletService.test.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../test/mocks/solana-keyring-accounts';
 import { getBip32EntropyMock } from '../../test/mocks/utils/getBip32Entropy';
 import logger from '../../utils/logger';
+import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { SolanaConnection } from '../connection';
 import { createMockConnection } from '../mocks/mockConnection';
 import { MOCK_EXECUTION_SCENARIOS } from '../signer/mocks/scenarios';
@@ -39,6 +40,7 @@ describe('WalletService', () => {
   let mockConnection: SolanaConnection;
   let mockSigner: Signer;
   let mockSignatureMonitor: SignatureMonitor;
+  let mockAnalyticsService: AnalyticsService;
   let service: WalletService;
   const mockAccounts = [...MOCK_SOLANA_KEYRING_ACCOUNTS];
   let onCommitmentReachedCallback: (params: any) => Promise<void>;
@@ -63,10 +65,15 @@ describe('WalletService', () => {
       },
     );
 
+    mockAnalyticsService = {
+      trackEventTransactionSubmitted: jest.fn(),
+    } as unknown as AnalyticsService;
+
     service = new WalletService(
       mockConnection,
       mockSigner,
       mockSignatureMonitor,
+      mockAnalyticsService,
       logger,
     );
 
@@ -284,6 +291,22 @@ describe('WalletService', () => {
             scope,
             'https://metamask.io',
           );
+        });
+
+        it('emits Transaction Submitted event after broadcasting', async () => {
+          await service.signAndSendTransaction(
+            fromAccount,
+            transactionMessageBase64Encoded,
+            scope,
+            'https://metamask.io',
+          );
+
+          expect(
+            mockAnalyticsService.trackEventTransactionSubmitted,
+          ).toHaveBeenCalledWith(fromAccount, signature, {
+            scope,
+            origin: 'https://metamask.io',
+          });
         });
       });
 

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -27,6 +27,7 @@ import { getSolanaExplorerUrl } from '../../utils/getSolanaExplorerUrl';
 import type { ILogger } from '../../utils/logger';
 import logger, { createPrefixedLogger } from '../../utils/logger';
 import { Base58Struct, Base64Struct } from '../../validation/structs';
+import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { SolanaConnection } from '../connection';
 import type { Signer } from '../signer/Signer';
 import type { SignatureMonitor } from '../subscriptions';
@@ -54,17 +55,21 @@ export class WalletService {
 
   readonly #signatureMonitor: SignatureMonitor;
 
+  readonly #analyticsService: AnalyticsService;
+
   readonly #logger: ILogger;
 
   constructor(
     connection: SolanaConnection,
     signer: Signer,
     signatureMonitor: SignatureMonitor,
+    analyticsService: AnalyticsService,
     _logger = logger,
   ) {
     this.#connection = connection;
     this.#signer = signer;
     this.#signatureMonitor = signatureMonitor;
+    this.#analyticsService = analyticsService;
     this.#logger = createPrefixedLogger(_logger, '[👛 WalletService]');
   }
 
@@ -287,6 +292,12 @@ export class WalletService {
     await sendTransactionWithoutConfirming(
       partiallySignedTransaction,
       sendConfig,
+    );
+
+    await this.#analyticsService.trackEventTransactionSubmitted(
+      account,
+      signature,
+      { scope, origin },
     );
 
     await this.#signatureMonitor.monitor(

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -220,6 +220,7 @@ const walletService = new WalletService(
   connection,
   signer,
   signatureMonitor,
+  analyticsService,
   logger,
 );
 


### PR DESCRIPTION
Addresses issues raised in [NEB-398](https://consensyssoftware.atlassian.net/jira/software/c/projects/NEB/boards/3738?assignee=62307b07c3a57b0068deaad3&selectedIssue=NEB-398) regarding missing Transaction Submitted analytics on Solana

### What was wrong
Transaction Submitted was tied to a SignatureMonitor path that expected a processed notification, but normal sign-and-send subscribes at confirmed. So the event often never fired, even though txs were still going through.

**What we did**

Fire Transaction Submitted in WalletService right after the tx is broadcast (after sendTransactionWithoutConfirming).
Remove that analytics call from SignatureMonitor, it still saves the tx on updates and emits Transaction Finalized for confirmed / finalized.
Inject AnalyticsService into WalletService via snapContext, with unit tests updated.

**Test plan**

- Run the test successfully`yarn workspace @metamask/solana-wallet-snap run test --testPathPattern="WalletService.test|SignatureMonitor.test" --no-coverage`
- Manual: one Sign & Send on a test build — tx should still complete as before.
- After release: check Mixpanel for Transaction Submitted on Solana mainnet vs previous snap/extension versions.

[NEB-398]: https://consensyssoftware.atlassian.net/browse/NEB-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves analytics emission into the `signAndSendTransaction` hot path and adds a new required `AnalyticsService` dependency to `WalletService`, so failures/latency in analytics could impact transaction flow if not handled upstream.
> 
> **Overview**
> Emits **`Transaction Submitted`** analytics in `WalletService.signAndSendTransaction` immediately after `sendTransactionWithoutConfirming`, ensuring the event fires even when monitoring starts at `confirmed`.
> 
> Removes the `processed`-commitment analytics emission from `SignatureMonitor` (it now just persists the transaction on any notification and only tracks **`Transaction Finalized`** for `confirmed`/`finalized`), updates DI wiring in `snapContext`, adjusts unit tests accordingly, and bumps the snap manifest `shasum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a23e07a80b11d23186ddc556822262ac72f0cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->