### PR TITLE
feat: harden `setSelectedAccounts`

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Validate that account IDs passed to `keyring_setSelectedAccounts` belong to the snap, rejecting unknown IDs with `InvalidParamsError` ([#604](https://github.com/MetaMask/snap-solana-wallet/pull/604))
+
 ## [2.8.0]
 
 ### Added

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "hFc9PK6QCElAWB+pnkHVzW3JQVj8UNub9NozdKIxAOQ=",
+    "shasum": "AzXzPnYm37l2ijVy4ZM6GRu3DouI8hs75QHbfXJ/sBQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
@@ -1012,5 +1012,18 @@ describe('SolanaKeyring', () => {
         ]),
       ).rejects.toThrow(InvalidParamsError);
     });
+
+    it('rejects if an account id is not part of existing accounts', async () => {
+      await expect(
+        keyring.setSelectedAccounts([
+          MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+          NON_EXISTENT_ACCOUNT_ID,
+        ]),
+      ).rejects.toThrow(InvalidParamsError);
+
+      expect(
+        mockKeyringAccountMonitor.setMonitoredAccounts,
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
@@ -29,6 +29,7 @@ import {
 import { emitSnapKeyringEvent } from '@metamask/keyring-snap-sdk';
 import type { CaipAssetType, Json, JsonRpcRequest } from '@metamask/snaps-sdk';
 import {
+  InvalidParamsError,
   MethodNotFoundError,
   SnapError,
   UserRejectedRequestError,
@@ -875,6 +876,16 @@ export class SolanaKeyring implements Keyring {
    */
   async setSelectedAccounts(accountIds: string[]): Promise<void> {
     validateRequest(accountIds, array(UuidStruct));
+
+    const existingIds = new Set(
+      (await this.#listAccounts()).map((account) => account.id),
+    );
+    if (!accountIds.every((id) => existingIds.has(id))) {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw new InvalidParamsError(
+        'Account IDs were not part of existing accounts.',
+      );
+    }
 
     await this.#keyringAccountMonitor.setMonitoredAccounts(accountIds);
   }


### PR DESCRIPTION
Brings the solana snap into parity with the BTC snap's behavior of validating if the accounts associated with the ids passed in exist in the snap or not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime validation for `keyring_setSelectedAccounts`, which may cause previously-tolerated client inputs to start failing and could impact account monitoring behavior if callers pass stale/foreign IDs.
> 
> **Overview**
> Hardens `keyring_setSelectedAccounts` by **rejecting any UUIDs that don’t correspond to accounts currently stored in the snap**, throwing `InvalidParamsError` instead of proceeding.
> 
> Adds a unit test to cover the new rejection path (and assert no monitor updates occur), updates the changelog entry, and refreshes the snap manifest `shasum` to reflect the rebuilt bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b0f28aa69bf519dc4afa73d5cf7eff1da1020a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->