### PR TITLE
fix: marinade multisig dapp requests by preserving original message bytes WPN-1035

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate that account IDs passed to `keyring_setSelectedAccounts` belong to the snap, rejecting unknown IDs with `InvalidParamsError` ([#604](https://github.com/MetaMask/snap-solana-wallet/pull/604))
 
+### Fixed
+
+- **BREAKING:** Preserve dapp-origin `signTransaction` and `signAndSendTransaction` payloads by signing the decoded transaction directly ([#608](https://github.com/MetaMask/snap-solana-wallet/pull/608))
+
 ## [2.8.0]
 
 ### Added

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "iJ+8qMIGrVGUFKqVoiq321vPMMrzfbh0pJypqrjfYZI=",
+    "shasum": "zH3kOh6woPQvIYkp0CGFGDdFyWcsGiACIMCGV4hmqwo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/sdk-extensions/codecs.test.ts
+++ b/packages/snap/src/core/sdk-extensions/codecs.test.ts
@@ -14,6 +14,7 @@ import {
   fromBytesToCompilableTransactionMessage,
   fromCompilableTransactionMessageToBase64String,
   fromTransactionToBase64String,
+  fromUnknowBase64StringToTransaction,
   fromUnknowBase64StringToTransactionOrTransactionMessage,
 } from './codecs';
 
@@ -84,6 +85,35 @@ describe('codecs', () => {
     describe(`fromBase64StringToTransaction | Scenario: ${name}`, () => {
       it('decodes a base64 string to a transaction', async () => {
         const result = await fromBase64StringToTransaction(
+          signedTransactionBase64Encoded,
+        );
+
+        const { lifetimeConstraint, ...rest } = signedTransaction;
+
+        expect(result).toStrictEqual(rest);
+      });
+    });
+
+    describe(`fromUnknowBase64StringToTransaction | Scenario: ${name}`, () => {
+      it('wraps bare compiled message bytes without changing the message bytes', async () => {
+        const transactionMessageBytes = pipe(
+          transactionMessage,
+          compileTransactionMessage,
+          getCompiledTransactionMessageEncoder().encode,
+        );
+
+        const result = await fromUnknowBase64StringToTransaction(
+          transactionMessageBase64Encoded,
+        );
+
+        expect(result.messageBytes).toStrictEqual(transactionMessageBytes);
+        expect(Object.values(result.signatures)).toStrictEqual(
+          Object.keys(result.signatures).map(() => null),
+        );
+      });
+
+      it('decodes a full transaction without changing the message bytes', async () => {
+        const result = await fromUnknowBase64StringToTransaction(
           signedTransactionBase64Encoded,
         );
 

--- a/packages/snap/src/core/sdk-extensions/codecs.ts
+++ b/packages/snap/src/core/sdk-extensions/codecs.ts
@@ -125,6 +125,35 @@ export const fromBase64StringToTransaction = async (
   pipe(base64String, getBase64Encoder().encode, getTransactionDecoder().decode);
 
 /**
+ * Decodes a base64 encoded compiled transaction message to a Transaction shape
+ * without changing the original message bytes.
+ *
+ * @param base64String - The base64 encoded compiled transaction message.
+ * @returns A transaction with null signature slots for all required signers.
+ */
+export const fromBase64StringCompiledMessageToTransaction = async (
+  base64String: Infer<typeof Base64Struct>,
+): Promise<Transaction> => {
+  const messageBytes = getBase64Encoder().encode(
+    base64String,
+  ) as TransactionMessageBytes;
+
+  const compiledTransactionMessage =
+    getCompiledTransactionMessageDecoder().decode(messageBytes);
+
+  const signerAccounts = compiledTransactionMessage.staticAccounts
+    .slice(0, compiledTransactionMessage.header.numSignerAccounts)
+    .map((address) => [address, null]);
+
+  const signatures = Object.fromEntries(signerAccounts);
+
+  return {
+    messageBytes,
+    signatures,
+  };
+};
+
+/**
  * Decodes a base64 string to a transaction or a compilable transaction message.
  *
  * @param base64String - The base64 string to decode.
@@ -140,4 +169,18 @@ export const fromUnknowBase64StringToTransactionOrTransactionMessage = async (
   PromiseAny<Transaction | CompilableTransactionMessage>([
     fromBase64StringToTransaction(base64String),
     fromBase64StringToCompilableTransactionMessage(base64String, rpc, config),
+  ]);
+
+/**
+ * Decodes a base64 string to a transaction.
+ *
+ * @param base64String - The base64 string to decode that represents either a transaction or a transaction message.
+ * @returns The decoded transaction.
+ */
+export const fromUnknowBase64StringToTransaction = async (
+  base64String: Infer<typeof Base64Struct>,
+): Promise<Transaction> =>
+  PromiseAny<Transaction>([
+    fromBase64StringToTransaction(base64String),
+    fromBase64StringCompiledMessageToTransaction(base64String),
   ]);

--- a/packages/snap/src/core/services/signer/Signer.test.ts
+++ b/packages/snap/src/core/services/signer/Signer.test.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 import {
+  getBase64Encoder,
   getSignatureFromTransaction,
   isTransactionMessageWithBlockhashLifetime,
 } from '@solana/kit';
@@ -120,6 +121,25 @@ describe('Signer', () => {
               transactionMessageAfterSigning,
             ),
           ).toBe(true);
+        });
+
+        it(`Scenario ${name}: preserves message bytes when requested`, async () => {
+          const originalMessageBytes = getBase64Encoder().encode(
+            transactionMessageBase64Encoded,
+          );
+
+          const result = await signer.partiallySignBase64String(
+            transactionMessageBase64Encoded,
+            fromAccount,
+            scope,
+            undefined,
+            true,
+          );
+
+          expect(result.messageBytes).toStrictEqual(originalMessageBytes);
+          expect(Object.values(result.signatures)).toStrictEqual([
+            expect.any(Uint8Array),
+          ]);
         });
       });
     });

--- a/packages/snap/src/core/services/signer/Signer.ts
+++ b/packages/snap/src/core/services/signer/Signer.ts
@@ -19,6 +19,7 @@ import type { Network } from '../../constants/solana';
 import type { DecompileTransactionMessageFetchingLookupTablesConfig } from '../../sdk-extensions/codecs';
 import {
   fromBytesToCompilableTransactionMessage,
+  fromUnknowBase64StringToTransaction,
   fromUnknowBase64StringToTransactionOrTransactionMessage,
 } from '../../sdk-extensions/codecs';
 import {
@@ -60,6 +61,7 @@ export class Signer {
    * @param account - The account to sign the transaction or transaction message with.
    * @param network - The network on which the transaction is being sent.
    * @param config - The configuration for the request.
+   * @param preserveMessageBytes - Whether to preserve the original message bytes.
    * @returns The signed transaction.
    * @throws If the base64 string is not a valid transaction or transaction message.
    */
@@ -68,6 +70,7 @@ export class Signer {
     account: SolanaKeyringAccount,
     network: Network,
     config?: DecompileTransactionMessageFetchingLookupTablesConfig,
+    preserveMessageBytes = false,
   ): Promise<Transaction> {
     this.#logger.log('Partially sign base64 string', {
       base64String,
@@ -75,6 +78,13 @@ export class Signer {
       network,
       config,
     });
+
+    if (preserveMessageBytes) {
+      const transaction =
+        await fromUnknowBase64StringToTransaction(base64String);
+
+      return this.#partiallySignTransaction(transaction, account);
+    }
 
     const rpc = this.#connection.getRpc(network);
 

--- a/packages/snap/src/core/services/wallet/WalletService.test.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.test.ts
@@ -1,6 +1,6 @@
 import { SolMethod } from '@metamask/keyring-api';
 
-import { Network } from '../../constants/solana';
+import { METAMASK_ORIGIN, Network } from '../../constants/solana';
 import {
   MOCK_SOLANA_KEYRING_ACCOUNT_0,
   MOCK_SOLANA_KEYRING_ACCOUNT_1,
@@ -243,6 +243,40 @@ describe('WalletService', () => {
           });
         });
 
+        it('requests byte preservation for dapp origins', async () => {
+          await service.signTransaction(
+            fromAccount,
+            transactionMessageBase64Encoded,
+            scope,
+            origin,
+          );
+
+          expect(mockSigner.partiallySignBase64String).toHaveBeenCalledWith(
+            transactionMessageBase64Encoded,
+            fromAccount,
+            scope,
+            undefined,
+            true,
+          );
+        });
+
+        it('does not request byte preservation for MetaMask origin', async () => {
+          await service.signTransaction(
+            fromAccount,
+            transactionMessageBase64Encoded,
+            scope,
+            METAMASK_ORIGIN,
+          );
+
+          expect(mockSigner.partiallySignBase64String).toHaveBeenCalledWith(
+            transactionMessageBase64Encoded,
+            fromAccount,
+            scope,
+            undefined,
+            false,
+          );
+        });
+
         it('starts monitoring the transaction for commitment "confirmed"', async () => {
           await service.signTransaction(
             fromAccount,
@@ -273,6 +307,40 @@ describe('WalletService', () => {
           expect(result).toStrictEqual({
             signature,
           });
+        });
+
+        it('requests byte preservation for dapp origins', async () => {
+          await service.signAndSendTransaction(
+            fromAccount,
+            transactionMessageBase64Encoded,
+            scope,
+            origin,
+          );
+
+          expect(mockSigner.partiallySignBase64String).toHaveBeenCalledWith(
+            transactionMessageBase64Encoded,
+            fromAccount,
+            scope,
+            undefined,
+            true,
+          );
+        });
+
+        it('does not request byte preservation for MetaMask origin', async () => {
+          await service.signAndSendTransaction(
+            fromAccount,
+            transactionMessageBase64Encoded,
+            scope,
+            METAMASK_ORIGIN,
+          );
+
+          expect(mockSigner.partiallySignBase64String).toHaveBeenCalledWith(
+            transactionMessageBase64Encoded,
+            fromAccount,
+            scope,
+            undefined,
+            false,
+          );
         });
 
         it('starts monitoring the transaction for commitment "confirmed"', async () => {

--- a/packages/snap/src/core/services/wallet/WalletService.ts
+++ b/packages/snap/src/core/services/wallet/WalletService.ts
@@ -18,7 +18,11 @@ import {
 } from '@solana/kit';
 
 import type { SolanaKeyringAccount } from '../../../entities';
-import type { Caip10Address, Network } from '../../constants/solana';
+import {
+  METAMASK_ORIGIN,
+  type Caip10Address,
+  type Network,
+} from '../../constants/solana';
 import type { DecompileTransactionMessageFetchingLookupTablesConfig } from '../../sdk-extensions/codecs';
 import { fromTransactionToBase64String } from '../../sdk-extensions/codecs';
 import { addressToCaip10 } from '../../utils/addressToCaip10';
@@ -179,12 +183,17 @@ export class WalletService {
           }
         : undefined;
 
+    // For transactions coming from DApps, preserve the original message bytes.
+    // Mutating them would change the signing payload and break multisig flows.
+    const shouldPreserveMessageBytes = origin !== METAMASK_ORIGIN;
+
     const partiallySignedTransaction =
       await this.#signer.partiallySignBase64String(
         transaction,
         account,
         scope,
         config,
+        shouldPreserveMessageBytes,
       );
 
     const signedTransactionBase64 = fromTransactionToBase64String(
@@ -250,12 +259,17 @@ export class WalletService {
           }
         : undefined;
 
+    // For transactions coming from DApps, preserve the original message bytes.
+    // Mutating them would change the signing payload and break multisig flows.
+    const shouldPreserveMessageBytes = origin !== METAMASK_ORIGIN;
+
     const partiallySignedTransaction =
       await this.#signer.partiallySignBase64String(
         transactionMessageBase64Encoded,
         account,
         scope,
         signConfig,
+        shouldPreserveMessageBytes,
       );
 
     const signature = getSignatureFromTransaction(partiallySignedTransaction);


### PR DESCRIPTION
Fixes multisig dapp transaction signing by preserving the original transaction payload for external dapp origins.

- Decode dapp-origin `signTransaction` and `signAndSendTransaction` requests as transactions directly, whether the payload is a full serialized transaction or a bare compiled transaction message.
- Append only the snap account's signature, preserving existing signatures, compiled `messageBytes`, account ordering, and instruction account indices.
- Keep the existing MetaMask-origin signing flow unchanged.
- Add coverage for codec decoding, signer byte preservation, and wallet origin handling.

https://github.com/user-attachments/assets/afe5602a-785b-4631-b120-df296612ac8c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transaction signing for all external dapps and is documented as breaking; incorrect decoding could break signing, though origin gating and tests limit blast radius.
> 
> **Overview**
> Fixes **multisig and dapp signing** (e.g. Marinade) by no longer decompiling and enriching dapp payloads before signing.
> 
> For **non-MetaMask origins**, `signTransaction` and `signAndSendTransaction` now decode the base64 payload as a **transaction** (full serialized tx or bare compiled message) and **only add the wallet’s signature**, keeping `messageBytes`, existing signatures, and account layout unchanged. MetaMask-origin requests still use the prior path that can fill fee payer, blockhash, and compute budget instructions.
> 
> New codec helpers (`fromBase64StringCompiledMessageToTransaction`, `fromUnknowBase64StringToTransaction`) and a `preserveMessageBytes` flag on `partiallySignBase64String` implement this. Changelog notes a **breaking** behavior change for dapp-origin signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a876dd4e437a3b4518151a5c9f2bc33f0d8d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->