### PR TITLE
chore: add npm package metadata links

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
+  "homepage": "https://github.com/MetaMask/snap-solana-wallet#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snap-solana-wallet/issues"
+  },
   "license": "(MIT-0 OR Apache-2.0)",
   "main": "./dist/bundle.js",
   "files": [


### PR DESCRIPTION
## Summary
- add package `homepage` metadata pointing to the repository README
- add npm-standard `bugs.url` metadata for the GitHub issue tracker

## Verification
- `npm view '@metamask/solana-wallet-snap@2.8.0' name version homepage repository bugs main files --json`
- parsed `packages/snap/package.json` with Node after the edit
- `npm pack --dry-run --json --ignore-scripts` against a scratch copy of the package manifest

This is metadata-only and does not change runtime code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only manifest edits with no effect on snap runtime or published bundle behavior.
> 
> **Overview**
> Adds standard npm package metadata to `@metamask/solana-wallet-snap` in `packages/snap/package.json`: a **`homepage`** field pointing at the repo README and a **`bugs.url`** field for the GitHub issue tracker.
> 
> No runtime, build, or dependency changes—only what registries and tooling surface for discoverability and support links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bb3babe90cec2a6dd77f6e1263fa6d685630b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->