### PR TITLE
feat: add `signProofOfOwnership` method for silent proof-of-ownership signing

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `signProofOfOwnership` client request method for silently signing `metamask:proof-of-ownership:<nonce>:<address>` messages with the account's ed25519 key
+
 ### Changed
 
 - Validate that account IDs passed to `keyring_setSelectedAccounts` belong to the snap, rejecting unknown IDs with `InvalidParamsError` ([#604](https://github.com/MetaMask/snap-solana-wallet/pull/604))

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `signProofOfOwnership` client request method for silently signing `metamask:proof-of-ownership:<nonce>:<address>` messages with the account's ed25519 key
+- Add `signProofOfOwnership` client request method ([#611](https://github.com/MetaMask/snap-solana-wallet/pull/611))
+  - This method silently signs `metamask:proof-of-ownership:<nonce>:<address>` messages with the account's ed25519 key
 
 ### Changed
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "AzXzPnYm37l2ijVy4ZM6GRu3DouI8hs75QHbfXJ/sBQ=",
+    "shasum": "hylVFA4wJ8uOJoroHz829PAybauyZeaIYAnpZnF5ybA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
@@ -643,6 +643,101 @@ describe('ClientRequestHandler', () => {
     });
   });
 
+  describe('signProofOfOwnership', () => {
+    const utf8ToBase64 = (utf8: string): string =>
+      pipe(utf8, getUtf8Codec().encode, getBase64Codec().decode);
+
+    const { id: accountId, address } = MOCK_SOLANA_KEYRING_ACCOUNT_0;
+    const nonce = 'a1b2c3d4e5f6789012345678';
+
+    const buildProofMessage = (
+      proofNonce: string = nonce,
+      proofAddress: string = address,
+    ): string =>
+      `metamask:proof-of-ownership:${proofNonce}:${proofAddress}`;
+
+    const createRequest = (message?: string): JsonRpcRequest => ({
+      jsonrpc: '2.0',
+      id: 1,
+      method: ClientRequestMethod.SignProofOfOwnership,
+      params: {
+        accountId,
+        message: message ?? buildProofMessage(),
+      },
+    });
+
+    it('signs the proof message and returns the signature', async () => {
+      const signature =
+        '61Go4ycewVBbfpDSP6hSad567y3USmUHbfR19wC2PA8uHEFGtWPpjyZnLrfH2yKLYkG7ezwT7jdE95NsVKUe1JNu';
+      const expectedBase64Message = utf8ToBase64(buildProofMessage());
+
+      jest
+        .spyOn(mockAccountsService, 'findById')
+        .mockResolvedValue(MOCK_SOLANA_KEYRING_ACCOUNT_0);
+      jest.spyOn(mockWalletService, 'signMessage').mockResolvedValue({
+        signature,
+        signedMessage: expectedBase64Message,
+        signatureType: 'ed25519' as const,
+      });
+
+      const result = await handler.handle(createRequest());
+
+      expect(mockWalletService.signMessage).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0,
+        expectedBase64Message,
+      );
+      expect(result).toStrictEqual({ signature });
+    });
+
+    it('throws if the message does not start with the proof prefix', async () => {
+      const invalidRequest = createRequest(
+        `rewards,${address},1736660000`,
+      );
+
+      await expect(handler.handle(invalidRequest)).rejects.toThrow(
+        'Message must start with',
+      );
+    });
+
+    it('throws if the account is not found', async () => {
+      mockAccountsService.findById.mockResolvedValue(null);
+
+      await expect(handler.handle(createRequest())).rejects.toThrow(
+        'Account not found',
+      );
+    });
+
+    it('throws if the address in the message does not match the signing account', async () => {
+      mockAccountsService.findById.mockResolvedValue(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0,
+      );
+
+      const otherAddress = MOCK_SOLANA_KEYRING_ACCOUNT_1.address;
+      const requestWithDifferentAddress = createRequest(
+        buildProofMessage(nonce, otherAddress),
+      );
+
+      await expect(
+        handler.handle(requestWithDifferentAddress),
+      ).rejects.toThrow(
+        `Address in proof-of-ownership message (${otherAddress}) does not match signing account address (${address})`,
+      );
+    });
+
+    it('propagates errors from the wallet service', async () => {
+      jest
+        .spyOn(mockAccountsService, 'findById')
+        .mockResolvedValue(MOCK_SOLANA_KEYRING_ACCOUNT_0);
+      jest
+        .spyOn(mockWalletService, 'signMessage')
+        .mockRejectedValue(new Error('signer unavailable'));
+
+      await expect(handler.handle(createRequest())).rejects.toThrow(
+        'signer unavailable',
+      );
+    });
+  });
+
   describe('signCardMessage', () => {
     // Helper function to convert a utf8 string to base64
     const utf8ToBase64 = (utf8: string): string =>

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
@@ -653,8 +653,7 @@ describe('ClientRequestHandler', () => {
     const buildProofMessage = (
       proofNonce: string = nonce,
       proofAddress: string = address,
-    ): string =>
-      `metamask:proof-of-ownership:${proofNonce}:${proofAddress}`;
+    ): string => `metamask:proof-of-ownership:${proofNonce}:${proofAddress}`;
 
     const createRequest = (message?: string): JsonRpcRequest => ({
       jsonrpc: '2.0',
@@ -690,9 +689,7 @@ describe('ClientRequestHandler', () => {
     });
 
     it('throws if the message does not start with the proof prefix', async () => {
-      const invalidRequest = createRequest(
-        `rewards,${address},1736660000`,
-      );
+      const invalidRequest = createRequest(`rewards,${address},1736660000`);
 
       await expect(handler.handle(invalidRequest)).rejects.toThrow(
         'Message must start with',
@@ -717,9 +714,7 @@ describe('ClientRequestHandler', () => {
         buildProofMessage(nonce, otherAddress),
       );
 
-      await expect(
-        handler.handle(requestWithDifferentAddress),
-      ).rejects.toThrow(
+      await expect(handler.handle(requestWithDifferentAddress)).rejects.toThrow(
         `Address in proof-of-ownership message (${otherAddress}) does not match signing account address (${address})`,
       );
     });

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
@@ -6,7 +6,13 @@ import {
   MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 import { assert, create } from '@metamask/superstruct';
-import { address as asAddress, compileTransaction } from '@solana/kit';
+import {
+  address as asAddress,
+  compileTransaction,
+  getBase64Codec,
+  getUtf8Codec,
+  pipe,
+} from '@solana/kit';
 
 import {
   METAMASK_ORIGIN,
@@ -32,12 +38,16 @@ import {
   OnAmountInputRequestStruct,
   OnConfirmSendRequestStruct,
   parseCardMessage,
+  parseProofOfOwnershipMessage,
   parseRewardsMessage,
   SignAndSendTransactionRequestStruct,
   type SignAndSendTransactionResponse,
   SignAndSendTransactionResponseStruct,
   SignAndSendTransactionWithoutConfirmationRequestStruct,
   SignCardMessageRequestStruct,
+  SignProofOfOwnershipRequestStruct,
+  type SignProofOfOwnershipResponse,
+  SignProofOfOwnershipResponseStruct,
   SignRewardsMessageRequestStruct,
   ValidationResponseStruct,
 } from './validation';
@@ -102,6 +112,8 @@ export class ClientRequestHandler {
         return this.#handleSignCardMessage(request);
       case ClientRequestMethod.ApproveCardAmount:
         return this.#handleApproveCardAmount(request);
+      case ClientRequestMethod.SignProofOfOwnership:
+        return this.#handleSignProofOfOwnership(request);
       default:
         throw new MethodNotFoundError() as Error;
     }
@@ -431,6 +443,53 @@ export class ClientRequestHandler {
     const result = { signature };
 
     assert(result, ApproveCardAmountResponseStruct);
+
+    return result;
+  }
+
+  /**
+   * Handles the signing of a proof-of-ownership message, of format `'metamask:proof-of-ownership:{nonce}:{address}'`.
+   * @param request - The JSON-RPC request containing the method and parameters.
+   * @returns The response to the JSON-RPC request.
+   * @throws {InvalidParamsError} If the account is not found or if the address in the message doesn't match the signing account.
+   */
+  async #handleSignProofOfOwnership(request: JsonRpcRequest): Promise<Json> {
+    assert(request, SignProofOfOwnershipRequestStruct);
+
+    const {
+      params: { accountId, message },
+    } = request;
+
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      throw new InvalidParamsError(`Account not found: ${accountId}`) as Error;
+    }
+
+    // Parse the proof-of-ownership message to extract the address
+    const { address: messageAddress } = parseProofOfOwnershipMessage(message);
+
+    // Validate that the address in the message matches the signing account
+    if (messageAddress !== account.address) {
+      throw new InvalidParamsError(
+        `Address in proof-of-ownership message (${messageAddress}) does not match signing account address (${account.address})`,
+      ) as Error;
+    }
+
+    // `WalletService.signMessage` expects a base64-encoded message
+    const base64Message = pipe(
+      message,
+      getUtf8Codec().encode,
+      getBase64Codec().decode,
+    );
+
+    const { signature } = await this.#walletService.signMessage(
+      account,
+      base64Message,
+    );
+
+    const result: SignProofOfOwnershipResponse = { signature };
+
+    assert(result, SignProofOfOwnershipResponseStruct);
 
     return result;
   }

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
@@ -448,7 +448,8 @@ export class ClientRequestHandler {
   }
 
   /**
-   * Handles the signing of a proof-of-ownership message, of format `'metamask:proof-of-ownership:{nonce}:{address}'`.
+   * Handles the silent signing of a proof-of-ownership message, of format `'metamask:proof-of-ownership:{nonce}:{address}'`.
+   * Used by `@metamask/profile-metrics-controller` to prove wallet control of an address; no user prompt, gated to the `metamask` origin (see `metamaskPermissions`) and bound to the message prefix.
    * @param request - The JSON-RPC request containing the method and parameters.
    * @returns The response to the JSON-RPC request.
    * @throws {InvalidParamsError} If the account is not found or if the address in the message doesn't match the signing account.

--- a/packages/snap/src/core/handlers/onClientRequest/types.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/types.ts
@@ -8,4 +8,5 @@ export enum ClientRequestMethod {
   SignRewardsMessage = 'signRewardsMessage',
   SignCardMessage = 'signCardMessage',
   ApproveCardAmount = 'approveCardAmount',
+  SignProofOfOwnership = 'signProofOfOwnership',
 }

--- a/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
@@ -4,6 +4,8 @@ import { getBase64Codec, getUtf8Codec, pipe } from '@solana/kit';
 import {
   CardMessageStruct,
   parseCardMessage,
+  parseProofOfOwnershipMessage,
+  ProofOfOwnershipMessageStruct,
   RewardsMessageStruct,
 } from './validation';
 
@@ -294,6 +296,77 @@ describe('validation', () => {
       'rejects non-string values: "%s"',
       (value) => {
         expect(is(value, CardMessageStruct)).toBe(false);
+      },
+    );
+  });
+
+  describe('ProofOfOwnershipMessageStruct / parseProofOfOwnershipMessage', () => {
+    const validSolanaAddress = '5F9jaU8pWmLJxCk3dHvC1e7d1sWQ9H2kgvA5g4TtK9hF';
+    const nonce = 'a1b2c3d4e5f6789012345678';
+
+    it('accepts a well-formed proof-of-ownership message', () => {
+      const message = `metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`;
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).not.toThrow();
+      expect(is(message, ProofOfOwnershipMessageStruct)).toBe(true);
+      expect(parseProofOfOwnershipMessage(message)).toStrictEqual({
+        nonce,
+        address: validSolanaAddress,
+      });
+    });
+
+    it.each([
+      `metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`,
+      // Nonce with mixed alphanumerics + dashes/underscores (we don't constrain format).
+      `metamask:proof-of-ownership:abc-DEF_123:${validSolanaAddress}`,
+    ])('validates valid messages: "%s"', (message) => {
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).not.toThrow();
+      expect(is(message, ProofOfOwnershipMessageStruct)).toBe(true);
+    });
+
+    it.each([
+      `rewards,${validSolanaAddress},123`,
+      `metamask:proof:${nonce}:${validSolanaAddress}`,
+      `Metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`,
+      `${nonce}:${validSolanaAddress}`,
+      '',
+    ])(
+      'rejects messages without the expected prefix: "%s"',
+      (message) => {
+        expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
+          'Message must start with "metamask:proof-of-ownership:"',
+        );
+        expect(is(message, ProofOfOwnershipMessageStruct)).toBe(false);
+      },
+    );
+
+    it('rejects messages missing the address separator', () => {
+      const message = `metamask:proof-of-ownership:${nonce}`;
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
+        'Message must follow the format',
+      );
+    });
+
+    it('rejects messages with an empty nonce', () => {
+      const message = `metamask:proof-of-ownership::${validSolanaAddress}`;
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
+        'non-empty nonce',
+      );
+    });
+
+    it.each([
+      `metamask:proof-of-ownership:${nonce}:`,
+      `metamask:proof-of-ownership:${nonce}:not-a-solana-address`,
+      `metamask:proof-of-ownership:${nonce}:0x1234567890abcdef1234567890abcdef12345678`,
+    ])('rejects invalid Solana addresses: "%s"', (message) => {
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
+        'Invalid Solana address in proof-of-ownership message',
+      );
+    });
+
+    it.each([123, null, undefined, {}, [], true])(
+      'rejects non-string values: "%s"',
+      (value) => {
+        expect(is(value, ProofOfOwnershipMessageStruct)).toBe(false);
       },
     );
   });

--- a/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.test.ts
@@ -306,7 +306,9 @@ describe('validation', () => {
 
     it('accepts a well-formed proof-of-ownership message', () => {
       const message = `metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`;
-      expect(() => assert(message, ProofOfOwnershipMessageStruct)).not.toThrow();
+      expect(() =>
+        assert(message, ProofOfOwnershipMessageStruct),
+      ).not.toThrow();
       expect(is(message, ProofOfOwnershipMessageStruct)).toBe(true);
       expect(parseProofOfOwnershipMessage(message)).toStrictEqual({
         nonce,
@@ -318,9 +320,23 @@ describe('validation', () => {
       `metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`,
       // Nonce with mixed alphanumerics + dashes/underscores (we don't constrain format).
       `metamask:proof-of-ownership:abc-DEF_123:${validSolanaAddress}`,
+      // Nonce containing colons (auth API treats nonces as opaque, addresses
+      // don't contain ':' so the parser splits on the LAST one).
+      `metamask:proof-of-ownership:ns:abc:123:${validSolanaAddress}`,
     ])('validates valid messages: "%s"', (message) => {
-      expect(() => assert(message, ProofOfOwnershipMessageStruct)).not.toThrow();
+      expect(() =>
+        assert(message, ProofOfOwnershipMessageStruct),
+      ).not.toThrow();
       expect(is(message, ProofOfOwnershipMessageStruct)).toBe(true);
+    });
+
+    it('preserves embedded colons in the nonce when parsing', () => {
+      const colonNonce = 'ns:abc:123';
+      const message = `metamask:proof-of-ownership:${colonNonce}:${validSolanaAddress}`;
+      expect(parseProofOfOwnershipMessage(message)).toStrictEqual({
+        nonce: colonNonce,
+        address: validSolanaAddress,
+      });
     });
 
     it.each([
@@ -329,15 +345,12 @@ describe('validation', () => {
       `Metamask:proof-of-ownership:${nonce}:${validSolanaAddress}`,
       `${nonce}:${validSolanaAddress}`,
       '',
-    ])(
-      'rejects messages without the expected prefix: "%s"',
-      (message) => {
-        expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
-          'Message must start with "metamask:proof-of-ownership:"',
-        );
-        expect(is(message, ProofOfOwnershipMessageStruct)).toBe(false);
-      },
-    );
+    ])('rejects messages without the expected prefix: "%s"', (message) => {
+      expect(() => assert(message, ProofOfOwnershipMessageStruct)).toThrow(
+        'Message must start with "metamask:proof-of-ownership:"',
+      );
+      expect(is(message, ProofOfOwnershipMessageStruct)).toBe(false);
+    });
 
     it('rejects messages missing the address separator', () => {
       const message = `metamask:proof-of-ownership:${nonce}`;

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -428,3 +428,89 @@ export const ComputeFeeResponseStruct = array(
 );
 
 export type ComputeFeeResponse = Infer<typeof ComputeFeeResponseStruct>;
+
+export const PROOF_OF_OWNERSHIP_MESSAGE_PREFIX = 'metamask:proof-of-ownership:';
+
+/**
+ * Utility function to parse a proof-of-ownership message, of format `'metamask:proof-of-ownership:{nonce}:{address}'`.
+ * Returns the parsed components or throws an error if invalid.
+ *
+ * @param message - The plaintext proof-of-ownership message.
+ * @returns Object containing the parsed nonce and address.
+ * @throws Error if the message format is invalid
+ */
+export function parseProofOfOwnershipMessage(message: string): {
+  nonce: string;
+  address: string;
+} {
+  if (!message.startsWith(PROOF_OF_OWNERSHIP_MESSAGE_PREFIX)) {
+    throw new Error(
+      `Message must start with "${PROOF_OF_OWNERSHIP_MESSAGE_PREFIX}"`,
+    );
+  }
+
+  const remainder = message.slice(PROOF_OF_OWNERSHIP_MESSAGE_PREFIX.length);
+  const separatorIdx = remainder.indexOf(':');
+  if (separatorIdx === -1) {
+    throw new Error(
+      'Message must follow the format "metamask:proof-of-ownership:{nonce}:{address}"',
+    );
+  }
+
+  const nonce = remainder.slice(0, separatorIdx);
+  const address = remainder.slice(separatorIdx + 1);
+
+  if (nonce === '') {
+    throw new Error(
+      'Proof-of-ownership message must contain a non-empty nonce',
+    );
+  }
+
+  if (!is(address, SolanaAddressStruct)) {
+    throw new Error('Invalid Solana address in proof-of-ownership message');
+  }
+
+  return { nonce, address };
+}
+
+/**
+ * Validates that a plaintext message follows the proof-of-ownership format:
+ * 'metamask:proof-of-ownership:{nonce}:{address}'
+ */
+export const ProofOfOwnershipMessageStruct = refine(
+  string(),
+  'ProofOfOwnershipMessage',
+  (value: string) => {
+    try {
+      parseProofOfOwnershipMessage(value);
+      return true;
+    } catch (error) {
+      return error instanceof Error
+        ? error.message
+        : 'Invalid proof-of-ownership message';
+    }
+  },
+);
+
+/**
+ * signProofOfOwnership request/response validation.
+ */
+export const SignProofOfOwnershipRequestParamsStruct = object({
+  accountId: UuidStruct,
+  message: ProofOfOwnershipMessageStruct,
+});
+
+export const SignProofOfOwnershipRequestStruct = object({
+  jsonrpc: JsonRpcVersionStruct,
+  id: JsonRpcIdStruct,
+  method: literal(ClientRequestMethod.SignProofOfOwnership),
+  params: SignProofOfOwnershipRequestParamsStruct,
+});
+
+export const SignProofOfOwnershipResponseStruct = object({
+  signature: Base58Struct,
+});
+
+export type SignProofOfOwnershipResponse = Infer<
+  typeof SignProofOfOwnershipResponseStruct
+>;

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -450,7 +450,7 @@ export function parseProofOfOwnershipMessage(message: string): {
   }
 
   const remainder = message.slice(PROOF_OF_OWNERSHIP_MESSAGE_PREFIX.length);
-  const separatorIdx = remainder.indexOf(':');
+  const separatorIdx = remainder.lastIndexOf(':');
   if (separatorIdx === -1) {
     throw new Error(
       'Message must follow the format "metamask:proof-of-ownership:{nonce}:{address}"',

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -63,6 +63,7 @@ const metamaskPermissions = new Set([
   RpcRequestMethod.GetFeeForTransaction,
   // Client methods
   ClientRequestMethod.SignAndSendTransactionWithoutConfirmation,
+  ClientRequestMethod.SignProofOfOwnership,
 ]);
 
 const metamask = 'metamask';


### PR DESCRIPTION
Related to: https://consensyssoftware.atlassian.net/browse/MUL-1903

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces silent cryptographic signing gated to the MetaMask origin, but misuse or permission misconfiguration could allow signing ownership proofs without user approval.
> 
> **Overview**
> Adds a new **`signProofOfOwnership`** client RPC that signs `metamask:proof-of-ownership:{nonce}:{address}` messages **without a user prompt**, returning an ed25519 signature for profile-metrics-style wallet ownership proofs.
> 
> The handler follows the same pattern as rewards/card signing: validate request params, load the account by ID, parse the message (nonce split on the **last** `:` so opaque nonces can contain colons), and **reject** if the embedded address does not match the signing account. The plaintext message is UTF-8–encoded to base64 before `WalletService.signMessage`.
> 
> **`signProofOfOwnership` is allowed only for the `metamask` origin** (not general dapp permissions). Changelog, manifest shasum, and unit tests for parsing, handler behavior, and permissions are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618095dd40e17a47b3c46b583cb94838662d1c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->