### PR TITLE
fix: return `ProofOfOwnership` signatures as 0x instead of base58

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Return the `signProofOfOwnership` signature as 0x-prefixed hex instead of base58 ([#XXX](https://github.com/MetaMask/snap-solana-wallet/pull/XXX))
+- Return the `signProofOfOwnership` signature as 0x-prefixed hex instead of base58 ([#617](https://github.com/MetaMask/snap-solana-wallet/pull/617))
 
 ## [2.9.0]
 

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Return the `signProofOfOwnership` signature as 0x-prefixed hex instead of base58 ([#XXX](https://github.com/MetaMask/snap-solana-wallet/pull/XXX))
+
 ## [2.9.0]
 
 ### Added

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "MF32nQ2nRWR+VSlSjIv/l5vtPZeTl+8YhpRvi+yYF/A=",
+    "shasum": "CVq3NBfA3Nhy+OMgxwxKd1kQWrZYLxjxOUGiHaD8YpM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.test.ts
@@ -665,16 +665,19 @@ describe('ClientRequestHandler', () => {
       },
     });
 
-    it('signs the proof message and returns the signature', async () => {
-      const signature =
-        '61Go4ycewVBbfpDSP6hSad567y3USmUHbfR19wC2PA8uHEFGtWPpjyZnLrfH2yKLYkG7ezwT7jdE95NsVKUe1JNu';
+    it('signs the proof message and returns the signature as 0x-prefixed hex', async () => {
+      // 64 bytes of 0x01 in base58 — the wallet-standard format
+      // `WalletService.signMessage` returns. The handler must transcode
+      // this to 0x-prefixed hex for the identity auth API.
+      const base58Signature =
+        '2AXDGYSE4f2sz7tvMMzyHvUfcoJmxudvdhBcmiUSo6ijwfYmfZYsKRxboQMPh3R4kUhXRVdtSXFXMheka4Rc4P2';
       const expectedBase64Message = utf8ToBase64(buildProofMessage());
 
       jest
         .spyOn(mockAccountsService, 'findById')
         .mockResolvedValue(MOCK_SOLANA_KEYRING_ACCOUNT_0);
       jest.spyOn(mockWalletService, 'signMessage').mockResolvedValue({
-        signature,
+        signature: base58Signature,
         signedMessage: expectedBase64Message,
         signatureType: 'ed25519' as const,
       });
@@ -685,7 +688,7 @@ describe('ClientRequestHandler', () => {
         MOCK_SOLANA_KEYRING_ACCOUNT_0,
         expectedBase64Message,
       );
-      expect(result).toStrictEqual({ signature });
+      expect(result).toStrictEqual({ signature: `0x${'01'.repeat(64)}` });
     });
 
     it('throws if the message does not start with the proof prefix', async () => {

--- a/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/ClientRequestHandler.ts
@@ -6,9 +6,11 @@ import {
   MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 import { assert, create } from '@metamask/superstruct';
+import { bytesToHex } from '@metamask/utils';
 import {
   address as asAddress,
   compileTransaction,
+  getBase58Codec,
   getBase64Codec,
   getUtf8Codec,
   pipe,
@@ -483,9 +485,13 @@ export class ClientRequestHandler {
       getBase64Codec().decode,
     );
 
-    const { signature } = await this.#walletService.signMessage(
-      account,
-      base64Message,
+    const { signature: base58Signature } =
+      await this.#walletService.signMessage(account, base64Message);
+
+    // Transcode the base58 signature to 0x-prefixed hex for the identity
+    // auth API; the dApp `signMessage` flow keeps its wallet-standard base58.
+    const signature = bytesToHex(
+      Uint8Array.from(getBase58Codec().encode(base58Signature)),
     );
 
     const result: SignProofOfOwnershipResponse = { signature };

--- a/packages/snap/src/core/handlers/onClientRequest/validation.ts
+++ b/packages/snap/src/core/handlers/onClientRequest/validation.ts
@@ -16,6 +16,7 @@ import {
   CaipAssetTypeStruct,
   JsonRpcIdStruct,
   JsonRpcVersionStruct,
+  StrictHexStruct,
 } from '@metamask/utils';
 import { getBase64Codec, getUtf8Codec, pipe } from '@solana/kit';
 
@@ -508,7 +509,12 @@ export const SignProofOfOwnershipRequestStruct = object({
 });
 
 export const SignProofOfOwnershipResponseStruct = object({
-  signature: Base58Struct,
+  /**
+   * 0x-prefixed hex encoding of the 64-byte ed25519 signature.
+   * The identity auth API mandates this encoding for `solana` proofs of
+   * ownership.
+   */
+  signature: StrictHexStruct,
 });
 
 export type SignProofOfOwnershipResponse = Infer<


### PR DESCRIPTION
Fixes `handleSignProofOfOwnership` so that it returns hex signatures instead of base58