### PR TITLE
fix: enable Corepack in `update-snap-version` release job

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -41,11 +41,10 @@ jobs:
       contents: write
     needs: create-release-pr
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
+          is-high-risk-environment: false
       - name: Update Snap Version
         id: update-release-pr
         shell: bash


### PR DESCRIPTION
## What

Swap the raw `actions/checkout@v4` + `actions/setup-node@v4` pair in the `update-snap-version` job of `.github/workflows/create-release-pr.yml` for `MetaMask/action-checkout-and-setup@v1`, matching the pattern this repo's `build-lint-test.yml` already uses.

## Why

Surfaced by #614 (`chore: bump Yarn to 4.17.0`). The `update-snap-version` job runs `yarn --immutable` directly on the runner, but it wasn't enabling Corepack, so it fell back to `ubuntu-latest`'s global Yarn 1.22 and bailed:

> error This project's package.json defines "packageManager": "yarn@4.17.0". However the current global version of Yarn is 1.22.22.

The composite action enables Corepack and installs the pinned Yarn 4.17.0, so `yarn --immutable` resolves the right binary.

## Notes

- The first job (`create-release-pr`) still uses raw `actions/checkout` + `actions/setup-node`. It keeps working because `MetaMask/action-create-release-pr@v3` self-bootstraps.