### PR TITLE
Revert "2.9.1 (#620)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-wallet-snap-monorepo",
-  "version": "2.9.1",
+  "version": "2.9.0",
   "private": true,
   "description": "",
   "homepage": "https://github.com/MetaMask/snap-solana-wallet#readme",

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.9.1]
-
 ### Fixed
 
 - Return the `signProofOfOwnership` signature as 0x-prefixed hex instead of base58 ([#617](https://github.com/MetaMask/snap-solana-wallet/pull/617))
@@ -1094,8 +1092,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sonarcloud to github workflow ([#25](https://github.com/MetaMask/snap-solana-wallet/pull/25))
 - Snap setup
 
-[Unreleased]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.9.1...HEAD
-[2.9.1]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.9.0...v2.9.1
+[Unreleased]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.9.0...HEAD
 [2.9.0]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.7.4...v2.8.0
 [2.7.4]: https://github.com/MetaMask/snap-solana-wallet/compare/v2.7.3...v2.7.4

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/solana-wallet-snap",
-  "version": "2.9.1",
+  "version": "2.9.0",
   "description": "A Solana wallet Snap.",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.9.1",
+  "version": "2.9.0",
   "description": "Manage Solana using MetaMask",
   "proposedName": "Solana",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "iJ+8qMIGrVGUFKqVoiq321vPMMrzfbh0pJypqrjfYZI=",
+    "shasum": "CVq3NBfA3Nhy+OMgxwxKd1kQWrZYLxjxOUGiHaD8YpM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Reverting Release PR commit as `action-npm-publish` needs to be bumped to v6 in order to work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only revert with no wallet or signing logic changes; main risk is release/process confusion if 2.9.1 was already published externally.
> 
> **Overview**
> Reverts the **2.9.1** release commit so the repo is back on **2.9.0** until npm publish automation is fixed (bump to `action-npm-publish` v6).
> 
> Version fields are set back to `2.9.0` in the root `package.json`, `packages/snap/package.json`, and `snap.manifest.json`, and the manifest **source shasum** is updated to match the reverted bundle. The changelog drops the `## [2.9.1]` release section and keeps the `signProofOfOwnership` hex-encoding fix under **`[Unreleased]`**, with compare links pointed at `v2.9.0` again.
> 
> There are **no application/runtime code changes** in this diff—only release versioning and changelog/manifest metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31adab02dbe8078e687e6ffd212dc7fc2407da6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->