### PR TITLE
chore: track suppressed WPN-1513

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "tL5sIl2cqcBuEQv2bedRbZGHwX4TH4SiwoJ46XQVt7I=",
+    "shasum": "LwxGS9NsFHNyEvDhxRCI5mPM/03EuBweZLyoZ8CWNsk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "iJ+8qMIGrVGUFKqVoiq321vPMMrzfbh0pJypqrjfYZI=",
+    "shasum": "tL5sIl2cqcBuEQv2bedRbZGHwX4TH4SiwoJ46XQVt7I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/clients/nft-api/NftApiClient.test.ts
+++ b/packages/snap/src/core/clients/nft-api/NftApiClient.test.ts
@@ -4,11 +4,16 @@ import { InMemoryCache } from '../../caching/InMemoryCache';
 import type { Serializable } from '../../serialization/types';
 import type { ConfigProvider } from '../../services/config';
 import { mockLogger } from '../../services/mocks/logger';
+import { trackError } from '../../utils/errors';
 import { MOCK_NFT_METADATA_RESPONSE_MAPPED } from './mocks/mockNftMetadataResponseMapped';
 import { MOCK_NFT_METADATA_RESPONSE_RAW } from './mocks/mockNftMetadataResponseRaw';
 import { MOCK_NFTS_LIST_RESPONSE_MAPPED } from './mocks/mockNftsListResponseMapped';
 import { MOCK_NFTS_LIST_RESPONSE_RAW } from './mocks/mockNftsListResponseRaw';
 import { NftApiClient } from './NftApiClient';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 const mockFetch = jest.fn();
 let mockCache: ICache<Serializable>;
@@ -123,9 +128,11 @@ describe('NftApiClient', () => {
     });
 
     it('should return null if the fetch fails', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('some-error'));
+      const error = new Error('some-error');
+      mockFetch.mockRejectedValueOnce(error);
       const nft = await client.getNftMetadata('some-token-address');
       expect(nft).toBeNull();
+      expect(trackError).toHaveBeenCalledWith(error);
     });
   });
 

--- a/packages/snap/src/core/clients/nft-api/NftApiClient.ts
+++ b/packages/snap/src/core/clients/nft-api/NftApiClient.ts
@@ -7,6 +7,7 @@ import { useCache } from '../../caching/useCache';
 import type { Serializable } from '../../serialization/types';
 import type { ConfigProvider } from '../../services/config';
 import { buildUrl } from '../../utils/buildUrl';
+import { trackError } from '../../utils/errors';
 import type { ILogger } from '../../utils/logger';
 import logger from '../../utils/logger';
 import { UrlStruct } from '../../validation/structs';
@@ -202,6 +203,7 @@ export class NftApiClient {
 
       return mappedData;
     } catch (error) {
+      await trackError(error);
       return null;
     }
   }

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.test.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.test.tsx
@@ -1,0 +1,84 @@
+import { SolMethod } from '@metamask/keyring-api';
+
+import { transactionScanService, state } from '../../../../snapContext';
+import { Network } from '../../../constants/solana';
+import { serialize } from '../../../serialization/serialize';
+import { trackError } from '../../../utils/errors';
+import { getInterfaceContext, updateInterface } from '../../../utils/interface';
+import { refreshConfirmationEstimation } from './refreshConfirmationEstimation';
+
+jest.mock('../../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
+
+jest.mock('../../../serialization/serialize', () => ({
+  serialize: jest.fn((value) => value),
+}));
+
+jest.mock('../../../utils/interface', () => ({
+  CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME: 'confirmation-interface',
+  getInterfaceContext: jest.fn(),
+  updateInterface: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../features/confirmation/views/ConfirmTransactionRequest/ConfirmTransactionRequest',
+  () => ({
+    ConfirmTransactionRequest: () => null,
+  }),
+);
+
+jest.mock('../../../../snapContext', () => ({
+  state: {
+    getKey: jest.fn(),
+  },
+  transactionScanService: {
+    scanTransaction: jest.fn(),
+  },
+}));
+
+const setupTest = () => {
+  const interfaceContext = {
+    account: {
+      address: 'BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP',
+    },
+    transaction: 'mock-transaction',
+    scope: Network.Mainnet,
+    method: SolMethod.SignAndSendTransaction,
+    origin: 'https://metamask.io',
+    preferences: {
+      simulateOnChainActions: true,
+    },
+    scanFetchStatus: 'fetched',
+  };
+
+  (state.getKey as jest.Mock).mockResolvedValue({
+    'confirmation-interface': 'interface-id',
+  });
+  (getInterfaceContext as jest.Mock).mockResolvedValue(interfaceContext);
+  (updateInterface as jest.Mock).mockResolvedValue(undefined);
+  (serialize as jest.Mock).mockImplementation((value) => value);
+};
+
+describe('refreshConfirmationEstimation', () => {
+  it('tracks refresh failures and restores the fetched state', async () => {
+    setupTest();
+
+    const error = new Error('Scan failed');
+
+    (transactionScanService.scanTransaction as jest.Mock).mockRejectedValue(
+      error,
+    );
+
+    await refreshConfirmationEstimation({ request: {} as any });
+
+    expect(trackError).toHaveBeenCalledWith(error);
+    expect(updateInterface).toHaveBeenLastCalledWith(
+      'interface-id',
+      null,
+      expect.objectContaining({
+        scanFetchStatus: 'fetched',
+      }),
+    );
+  });
+});

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshConfirmationEstimation.tsx
@@ -5,6 +5,7 @@ import type { ConfirmTransactionRequestContext } from '../../../../features/conf
 import { state, transactionScanService } from '../../../../snapContext';
 import { serialize } from '../../../serialization/serialize';
 import type { UnencryptedStateValue } from '../../../services/state/State';
+import { trackError } from '../../../utils/errors';
 import {
   CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME,
   getInterfaceContext,
@@ -125,6 +126,8 @@ export const refreshConfirmationEstimation: OnCronjobHandler = async () => {
       },
     });
   } catch (error) {
+    await trackError(error);
+
     // Check if context exists in case the UI was closed, nothing to rollback
     const fetchedInterfaceContext =
       await getInterfaceContext<ConfirmTransactionRequestContext>(

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.test.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.test.tsx
@@ -1,0 +1,86 @@
+import { assetsService, priceApiClient, state } from '../../../../snapContext';
+import { KnownCaip19Id } from '../../../constants/solana';
+import { trackError } from '../../../utils/errors';
+import {
+  getInterfaceContext,
+  getPreferences,
+  updateInterface,
+} from '../../../utils/interface';
+import { refreshSend } from './refreshSend';
+
+jest.mock('../../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
+
+jest.mock('../../../utils/interface', () => ({
+  getInterfaceContext: jest.fn(),
+  getPreferences: jest.fn(),
+  SEND_FORM_INTERFACE_NAME: 'send-form',
+  updateInterface: jest.fn(),
+}));
+
+jest.mock('../../../../features/send/render', () => ({
+  DEFAULT_SEND_CONTEXT: {
+    preferences: {
+      locale: 'en',
+      currency: 'usd',
+    },
+  },
+}));
+
+jest.mock('../../../../features/send/Send', () => ({
+  Send: () => null,
+}));
+
+jest.mock('../../../../snapContext', () => ({
+  assetsService: {
+    getAll: jest.fn(),
+  },
+  priceApiClient: {
+    getMultipleSpotPrices: jest.fn(),
+  },
+  state: {
+    getKey: jest.fn(),
+    setKey: jest.fn(),
+  },
+}));
+
+const setupTest = () => {
+  (globalThis as any).snap = {
+    request: jest.fn(),
+  };
+
+  (assetsService.getAll as jest.Mock).mockResolvedValue([
+    {
+      assetType: KnownCaip19Id.SolMainnet,
+    },
+  ] as any);
+  (state.getKey as jest.Mock).mockResolvedValue({
+    'send-form': 'interface-id',
+  });
+  (getPreferences as jest.Mock).mockResolvedValue({
+    locale: 'en',
+    currency: 'usd',
+  });
+  (getInterfaceContext as jest.Mock).mockResolvedValue({
+    tokenPrices: {},
+  });
+  (updateInterface as jest.Mock).mockResolvedValue(undefined);
+};
+
+describe('refreshSend', () => {
+  it('tracks background refresh errors', async () => {
+    setupTest();
+
+    const error = new Error('Price API failed');
+
+    (priceApiClient.getMultipleSpotPrices as jest.Mock).mockRejectedValue(
+      error,
+    );
+
+    await refreshSend({ request: {} as any });
+
+    expect(trackError).toHaveBeenCalledWith(error);
+    expect(updateInterface).not.toHaveBeenCalled();
+  });
+});

--- a/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
+++ b/packages/snap/src/core/handlers/onCronjob/backgroundEvents/refreshSend.tsx
@@ -5,6 +5,7 @@ import { Send } from '../../../../features/send/Send';
 import type { SendContext } from '../../../../features/send/types';
 import { assetsService, priceApiClient, state } from '../../../../snapContext';
 import type { UnencryptedStateValue } from '../../../services/state/State';
+import { trackError } from '../../../utils/errors';
 import {
   getInterfaceContext,
   getPreferences,
@@ -89,6 +90,7 @@ export const refreshSend: OnCronjobHandler = async () => {
       params: { duration: 'PT30S', request: { method: 'refreshSend' } },
     });
   } catch (error) {
+    await trackError(error);
     logger.warn({ error }, `Could not refresh send interface`);
   }
 };

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.test.ts
@@ -46,6 +46,7 @@ import {
   MOCK_SOLANA_SEED_PHRASE_2_KEYRING_ACCOUNT_1,
 } from '../../test/mocks/solana-keyring-accounts';
 import { getBip32EntropyMock } from '../../test/mocks/utils/getBip32Entropy';
+import { trackError } from '../../utils/errors';
 import { getBip32Entropy } from '../../utils/getBip32Entropy';
 import logger from '../../utils/logger';
 import { SolanaKeyring } from './Keyring';
@@ -57,6 +58,10 @@ jest.mock('@metamask/keyring-snap-sdk', () => ({
 
 jest.mock('../../utils/getBip32Entropy', () => ({
   getBip32Entropy: getBip32EntropyMock,
+}));
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
 }));
 
 const NON_EXISTENT_ACCOUNT_ID = '123e4567-e89b-12d3-a456-426614174009';
@@ -738,13 +743,15 @@ describe('SolanaKeyring', () => {
     it('returns null when an error occurs', async () => {
       const mockScope = Network.Localnet;
       const mockRequest = {
-        method: 'someMethod',
-        params: [],
+        id: 1,
+        jsonrpc: '2.0',
+        ...MOCK_SIGN_AND_SEND_TRANSACTION_REQUEST,
       } as unknown as JsonRpcRequest;
+      const error = new Error('Something went wrong');
 
       jest
         .spyOn(mockWalletService, 'resolveAccountAddress')
-        .mockRejectedValue(new Error('Something went wrong'));
+        .mockRejectedValue(error);
 
       const result = await keyring.resolveAccountAddress(
         mockScope,
@@ -752,6 +759,7 @@ describe('SolanaKeyring', () => {
       );
 
       expect(result).toBeNull();
+      expect(trackError).toHaveBeenCalledWith(error);
     });
   });
 

--- a/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
+++ b/packages/snap/src/core/handlers/onKeyringRequest/Keyring.ts
@@ -60,6 +60,7 @@ import {
   deriveSolanaKeypair,
   deriveSolanaKeypairFromCoinTypeNode,
 } from '../../utils/deriveSolanaKeypair';
+import { trackError } from '../../utils/errors';
 import { getBip32Entropy } from '../../utils/getBip32Entropy';
 import { getLowestUnusedIndex } from '../../utils/getLowestUnusedIndex';
 import {
@@ -802,6 +803,7 @@ export class SolanaKeyring implements Keyring {
 
       return { address: caip10Address };
     } catch (error: any) {
+      await trackError(error);
       this.#logger.error({ error }, 'Error resolving account address');
       return null;
     }

--- a/packages/snap/src/core/services/analytics/AnalyticsService.test.ts
+++ b/packages/snap/src/core/services/analytics/AnalyticsService.test.ts
@@ -4,8 +4,13 @@ import type { Transaction } from '@metamask/keyring-api';
 
 import { Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNT_0 } from '../../test/mocks/solana-keyring-accounts';
+import { trackError } from '../../utils/errors';
 import { ScanStatus, SecurityAlertResponse } from '../transaction-scan/types';
 import { AnalyticsService } from './AnalyticsService';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 const mockSnapRequest = jest.fn();
 const snap = {
@@ -52,6 +57,18 @@ describe('AnalyticsService', () => {
           },
         },
       });
+    });
+
+    it('tracks analytics failures', async () => {
+      const error = new Error('Tracking failed');
+      mockSnapRequest.mockRejectedValueOnce(error);
+
+      await analyticsService.trackEventTransactionAdded(
+        mockAccount,
+        mockMetadata,
+      );
+
+      expect(trackError).toHaveBeenCalledWith(error);
     });
   });
 

--- a/packages/snap/src/core/services/analytics/AnalyticsService.ts
+++ b/packages/snap/src/core/services/analytics/AnalyticsService.ts
@@ -4,6 +4,7 @@ import type { Json } from '@metamask/utils';
 
 import type { SolanaKeyringAccount } from '../../../entities';
 import type { Network, TransactionMetadata } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import type { ILogger } from '../../utils/logger';
 import logger, { createPrefixedLogger } from '../../utils/logger';
 import type {
@@ -38,6 +39,7 @@ export class AnalyticsService {
         },
       });
     } catch (error) {
+      await trackError(error);
       this.#logger.warn('Error tracking event', {
         error,
         event,

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../entities';
 import { KnownCaip19Id, Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNTS } from '../../test/mocks/solana-keyring-accounts';
+import { trackError } from '../../utils/errors';
 import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
 import type { AssetsService, TokenHelper } from '../assets';
@@ -23,6 +24,10 @@ import { mockLogger } from '../mocks/logger';
 import type { TransactionsService } from '../transactions';
 import { KeyringAccountMonitor } from './KeyringAccountMonitor';
 import type { SubscriptionService } from './SubscriptionService';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('KeyringAccountMonitor', () => {
   let keyringAccountMonitor: KeyringAccountMonitor;
@@ -501,6 +506,21 @@ describe('KeyringAccountMonitor', () => {
         jest
           .spyOn(mockTokenHelper, 'amountToUiAmountForMint')
           .mockResolvedValue('123.456789');
+      });
+
+      it('tracks ui amount fallback errors and keeps the raw value', async () => {
+        const error = new Error('Conversion failed');
+
+        jest
+          .spyOn(mockTokenHelper, 'amountToUiAmountForMint')
+          .mockRejectedValue(error);
+
+        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
+
+        const handler = programNotificationHandlers[0]!;
+        await handler(mockNotification, mockSubscription);
+
+        expect(trackError).toHaveBeenCalledWith(error);
       });
 
       it('saves the new balance of the token asset and the transaction that caused it', async () => {

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../../entities';
 import type { Network } from '../../constants/solana';
 import { SolanaCaip19Tokens } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import { fromTokenUnits } from '../../utils/fromTokenUnit';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
@@ -390,7 +391,8 @@ export class KeyringAccountMonitor {
      */
     const uiAmount = await this.#tokenHelper
       .amountToUiAmountForMint(mint, network, lamports(BigInt(amount)))
-      .catch((error) => {
+      .catch(async (error) => {
+        await trackError(error);
         this.#logger.error('Error converting amount to uiAmount', error);
         return uiAmountString;
       });

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.test.ts
@@ -9,15 +9,19 @@ import type {
 } from '../../../entities';
 import { Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNTS } from '../../test/mocks/solana-keyring-accounts';
+import { trackError } from '../../utils/errors';
 import type { AccountsService } from '../accounts';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { ConfigProvider } from '../config';
-import type { Config } from '../config/ConfigProvider';
 import type { SolanaConnection } from '../connection';
 import { mockLogger } from '../mocks/logger';
 import type { TransactionsService } from '../transactions';
 import { SignatureMonitor } from './SignatureMonitor';
 import type { SubscriptionService } from './SubscriptionService';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('SignatureMonitor', () => {
   let signatureMonitor: SignatureMonitor;
@@ -225,6 +229,39 @@ describe('SignatureMonitor', () => {
         scope: network,
       });
 
+      expect(mockSubscriptionService.unsubscribe).toHaveBeenCalledWith(
+        mockSubscription.id,
+      );
+    });
+
+    it('tracks notification handling errors and still unsubscribes', async () => {
+      const error = new Error('Save failed');
+      const mockNotification = {} as unknown as SignatureNotification;
+      const mockSubscription = {
+        id: 'subscription-id-123',
+        method: 'signatureSubscribe',
+        network: Network.Mainnet,
+        params: [signature, { commitment, enableReceivedNotification: false }],
+        metadata: {
+          accountId,
+          origin,
+        },
+      } as unknown as Subscription;
+
+      jest.spyOn(mockTransactionsService, 'save').mockRejectedValue(error);
+
+      await signatureMonitor.monitor(
+        signature,
+        accountId,
+        'confirmed',
+        network,
+        origin,
+      );
+
+      const handler = notificationHandlers[0]!;
+      await handler(mockNotification, mockSubscription);
+
+      expect(trackError).toHaveBeenCalledWith(error);
       expect(mockSubscriptionService.unsubscribe).toHaveBeenCalledWith(
         mockSubscription.id,
       );

--- a/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/SignatureMonitor.ts
@@ -11,6 +11,7 @@ import {
   type SubscriptionRequest,
 } from '../../../entities';
 import type { Network } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { AccountsService } from '../accounts/AccountsService';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
@@ -198,6 +199,7 @@ export class SignatureMonitor {
           this.#logger.warn(`⚠️ Commitment ${commitment} not supported`);
       }
     } catch (error) {
+      await trackError(error);
       this.#logger.error('Error handling signature notification', error);
     } finally {
       // Always unsubscribe and clean up, regardless of success or failure

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.test.ts
@@ -1,9 +1,10 @@
 import type { WebSocketConnection } from '../../../entities';
 import { EventEmitter } from '../../../infrastructure';
 import { Network } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { ConfigProvider } from '../config';
-import type { Config, NetworkConfig } from '../config/ConfigProvider';
+import type { NetworkConfig } from '../config/ConfigProvider';
 import { mockLogger } from '../mocks/logger';
 import { InMemoryState } from '../state/InMemoryState';
 import type { IStateManager } from '../state/IStateManager';
@@ -13,6 +14,10 @@ import {
 } from '../state/State';
 import type { WebSocketConnectionRepository } from './WebSocketConnectionRepository';
 import { WebSocketConnectionService } from './WebSocketConnectionService';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 const mockWebSocketUrl = 'wss://some-mock-url.com/ws/v3/some-id';
 const mockConnectionId = 'mock-connection-id';
@@ -523,11 +528,12 @@ describe('WebSocketConnectionService', () => {
       it('handles cancellation errors gracefully', async () => {
         const existingEventId = 'existing-event-id';
         const newEventId = 'new-event-id';
+        const error = new Error('Cancel failed');
 
         jest.spyOn(mockState, 'getKey').mockResolvedValueOnce(existingEventId);
         jest
           .spyOn(snap, 'request')
-          .mockRejectedValueOnce(new Error('Cancel failed'))
+          .mockRejectedValueOnce(error)
           .mockResolvedValueOnce(newEventId);
         jest.spyOn(mockState, 'setKey').mockResolvedValue(undefined);
 
@@ -541,6 +547,7 @@ describe('WebSocketConnectionService', () => {
             request: { method: 'closeWebSocketConnections' },
           },
         });
+        expect(trackError).toHaveBeenCalledWith(error);
       });
     });
 

--- a/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
+++ b/packages/snap/src/core/services/subscriptions/WebSocketConnectionService.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../entities';
 import type { EventEmitter } from '../../../infrastructure';
 import type { Network } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import { getClientStatus } from '../../utils/interface';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
@@ -434,6 +435,7 @@ export class WebSocketConnectionService {
         eventId,
       );
     } catch (error) {
+      await trackError(error);
       this.#logger.warn(`Failed to cancel background event`, error);
     } finally {
       // Clear the state

--- a/packages/snap/src/core/services/token-prices/TokenPrices.test.ts
+++ b/packages/snap/src/core/services/token-prices/TokenPrices.test.ts
@@ -6,9 +6,14 @@ import { MOCK_SPOT_PRICES } from '../../clients/price-api/mocks/spot-prices';
 import type { PriceApiClient } from '../../clients/price-api/PriceApiClient';
 import type { SpotPrice } from '../../clients/price-api/types';
 import { MOCK_EXCHANGE_RATES } from '../../test/mocks/price-api/exchange-rates';
+import { trackError } from '../../utils/errors';
 import { ConfigProvider } from '../config';
 import { mockLogger } from '../mocks/logger';
 import { TokenPricesService } from './TokenPrices';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('TokenPricesService', () => {
   /* Crypto */
@@ -501,6 +506,18 @@ describe('TokenPricesService', () => {
         updateTime: expect.any(Number),
         expirationTime: expect.any(Number),
       });
+    });
+
+    it('tracks historical price fetch failures', async () => {
+      const error = new Error('History failed');
+
+      jest
+        .spyOn(mockPriceApiClient, 'getHistoricalPrices')
+        .mockRejectedValueOnce(error);
+
+      await tokenPricesService.getHistoricalPrice(BTC, USD);
+
+      expect(trackError).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/packages/snap/src/core/services/token-prices/TokenPrices.ts
+++ b/packages/snap/src/core/services/token-prices/TokenPrices.ts
@@ -17,6 +17,7 @@ import {
   VsCurrencyParamStruct,
   type FiatTicker,
 } from '../../clients/price-api/types';
+import { trackError } from '../../utils/errors';
 import { isFiat } from '../../utils/isFiat';
 import { type ILogger } from '../../utils/logger';
 import type { ConfigProvider } from '../config';
@@ -373,7 +374,8 @@ export class TokenPricesService {
           response,
         }))
         // Gracefully handle individual errors to avoid breaking the entire operation
-        .catch((error) => {
+        .catch(async (error) => {
+          await trackError(error);
           this.#logger.warn(
             `Error fetching historical prices for ${from} to ${to} with time period ${timePeriod}. Returning null object.`,
             error,

--- a/packages/snap/src/core/services/transaction-scan/TransactionScan.test.ts
+++ b/packages/snap/src/core/services/transaction-scan/TransactionScan.test.ts
@@ -3,10 +3,15 @@ import type { SecurityAlertsApiClient } from '../../clients/security-alerts-api/
 import type { SecurityAlertSimulationValidationResponse } from '../../clients/security-alerts-api/types';
 import { Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNT_0 } from '../../test/mocks/solana-keyring-accounts';
+import { trackError } from '../../utils/errors';
 import type { ILogger } from '../../utils/logger';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import { TransactionScanService } from './TransactionScan';
 import { ScanStatus, SecurityAlertResponse } from './types';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('TransactionScan', () => {
   let transactionScanService: TransactionScanService;
@@ -57,9 +62,10 @@ describe('TransactionScan', () => {
     });
 
     it('returns null if the scan fails', async () => {
+      const error = new Error('Scan failed');
       jest
         .spyOn(mockSecurityAlertsApiClient, 'scanTransactions')
-        .mockRejectedValue(new Error('Scan failed'));
+        .mockRejectedValue(error);
 
       const result = await transactionScanService.scanTransaction({
         method: 'method',
@@ -70,6 +76,7 @@ describe('TransactionScan', () => {
       });
 
       expect(result).toBeNull();
+      expect(trackError).toHaveBeenCalledWith(error);
     });
 
     it('tracks security scan completion when account is provided', async () => {

--- a/packages/snap/src/core/services/transaction-scan/TransactionScan.ts
+++ b/packages/snap/src/core/services/transaction-scan/TransactionScan.ts
@@ -7,6 +7,7 @@ import {
   METAMASK_ORIGIN_URL,
   type Network,
 } from '../../constants/solana';
+import { trackError } from '../../utils/errors';
 import type { ILogger } from '../../utils/logger';
 import type { AnalyticsService } from '../analytics/AnalyticsService';
 import type { TransactionScanResult, TransactionScanValidation } from './types';
@@ -143,6 +144,7 @@ export class TransactionScanService {
       // Logo URLs are passed directly to Image component - no conversion needed
       return scan;
     } catch (error) {
+      await trackError(error);
       this.#logger.error(error);
 
       if (account) {

--- a/packages/snap/src/core/services/transactions/TransactionMapper.test.ts
+++ b/packages/snap/src/core/services/transactions/TransactionMapper.test.ts
@@ -19,9 +19,14 @@ import { EXPECTED_SWAP_TRUMP_TO_JUP_DATA } from '../../test/mocks/transactions-d
 import { EXPECTED_SWAP_USDC_TO_COBIE_DATA } from '../../test/mocks/transactions-data/swap-usdc-to-cobie';
 import { EXPECTED_SWAP_USDC_TO_JUP_DATA } from '../../test/mocks/transactions-data/swap-usdc-to-jup';
 import type { SolanaTransaction } from '../../types/solana';
+import { trackError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import type { AssetsService, TokenHelper } from '../assets';
 import { TransactionMapper } from './TransactionMapper';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('TransactionMapper', () => {
   let transactionMapper: TransactionMapper;
@@ -277,6 +282,30 @@ describe('TransactionMapper', () => {
           },
         ],
       });
+    });
+
+    it('tracks mapping errors', async () => {
+      const invalidTransaction = {
+        ...EXPECTED_NATIVE_SOL_TRANSFER_DATA,
+        transaction: {
+          ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction,
+          signatures: [],
+        },
+      } as unknown as SolanaTransaction;
+
+      expect(
+        await transactionMapper.mapRpcTransaction(
+          invalidTransaction,
+          mockAccount,
+          Network.Mainnet,
+        ),
+      ).toBeNull();
+
+      expect(trackError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Transaction ID is required',
+        }),
+      );
     });
 
     it('maps SPL token transfers - as a sender', async () => {

--- a/packages/snap/src/core/services/transactions/TransactionMapper.ts
+++ b/packages/snap/src/core/services/transactions/TransactionMapper.ts
@@ -22,6 +22,7 @@ import {
 } from '../../constants/solana';
 import type { SolanaTransaction } from '../../types/solana';
 import { lamportsToSol } from '../../utils/conversion';
+import { trackError } from '../../utils/errors';
 import type { ILogger } from '../../utils/logger';
 import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
 import type { AssetMetadata } from '../assets/types';
@@ -174,6 +175,7 @@ export class TransactionMapper {
         ],
       };
     } catch (error) {
+      await trackError(error);
       this.#logger.warn(error, 'Error mapping transaction');
       return null;
     }

--- a/packages/snap/src/core/services/transactions/TransactionsService.test.ts
+++ b/packages/snap/src/core/services/transactions/TransactionsService.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { type Transaction } from '@metamask/keyring-api';
 import { address as asAddress } from '@solana/kit';
+import type { NativeAsset } from 'src/entities';
 
-import { Network } from '../../constants/solana';
+import { KnownCaip19Id, Network } from '../../constants/solana';
 import {
   MOCK_SOLANA_KEYRING_ACCOUNT_0,
   MOCK_SOLANA_KEYRING_ACCOUNT_1,
 } from '../../test/mocks/solana-keyring-accounts';
 import { MOCK_GET_SIGNATURES_FOR_ADDRESS } from '../../test/mocks/transactions';
 import { ADDRESS_1_TRANSACTION_1_DATA } from '../../test/mocks/transactions-data/address-1/transaction-1';
+import { trackError } from '../../utils/errors';
 import type { AccountsService } from '../accounts/AccountsService';
 import type { AssetsService } from '../assets/AssetsService';
 import type { SolanaConnection } from '../connection/SolanaConnection';
@@ -17,6 +19,10 @@ import { createMockConnection } from '../mocks/mockConnection';
 import type { TransactionMapper } from './TransactionMapper';
 import type { TransactionsRepository } from './TransactionsRepository';
 import { TransactionsService } from './TransactionsService';
+
+jest.mock('../../utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 jest.mock('@metamask/keyring-snap-sdk', () => ({
   emitSnapKeyringEvent: jest.fn(),
@@ -33,6 +39,7 @@ describe('TransactionsService', () => {
   beforeEach(() => {
     mockTransactionsRepository = {
       findByAccountId: jest.fn(),
+      getAll: jest.fn(),
       saveMany: jest.fn(),
     } as unknown as TransactionsRepository;
 
@@ -159,6 +166,42 @@ describe('TransactionsService', () => {
         mockTransaction01,
         mockTransaction10,
       ]);
+    });
+  });
+
+  describe('fetchAssetsTransactions', () => {
+    it('tracks transaction fetch errors and continues', async () => {
+      const asset = {
+        assetType: KnownCaip19Id.SolMainnet,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        symbol: 'SOL',
+        decimals: 9,
+        rawAmount: '1',
+        uiAmount: '1',
+      } as NativeAsset;
+      const error = new Error('RPC failed');
+
+      jest
+        .spyOn(mockAccountsService, 'getAll')
+        .mockResolvedValue([MOCK_SOLANA_KEYRING_ACCOUNT_0]);
+      jest.spyOn(mockAssetsService, 'getAssetsMetadata').mockResolvedValue({});
+      jest.spyOn(mockTransactionsRepository, 'getAll').mockResolvedValue([]);
+      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
+        getSignaturesForAddress: jest.fn().mockReturnValue({
+          send: jest
+            .fn()
+            .mockResolvedValue([MOCK_GET_SIGNATURES_FOR_ADDRESS[0]]),
+        }),
+        getTransaction: jest.fn().mockReturnValue({
+          send: jest.fn().mockRejectedValue(error),
+        }),
+      } as any);
+
+      expect(await service.fetchAssetsTransactions([asset])).toStrictEqual([]);
+      expect(trackError).toHaveBeenCalledTimes(1);
+      expect(trackError).toHaveBeenCalledWith(error);
     });
   });
 

--- a/packages/snap/src/core/services/transactions/TransactionsService.ts
+++ b/packages/snap/src/core/services/transactions/TransactionsService.ts
@@ -8,6 +8,7 @@ import type { AssetEntity } from '../../../entities';
 import type { SolanaKeyringAccount } from '../../../entities/keyring-account';
 import { type Network } from '../../constants/solana';
 import type { SolanaTransaction } from '../../types/solana';
+import { trackError } from '../../utils/errors';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
 import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
 import type { AccountsService } from '../accounts';
@@ -193,6 +194,7 @@ export class TransactionsService {
           asset,
         };
       } catch (error) {
+        await trackError(error);
         return null;
       }
     };

--- a/packages/snap/src/core/utils/deriveSolanaKeypair.ts
+++ b/packages/snap/src/core/utils/deriveSolanaKeypair.ts
@@ -60,6 +60,8 @@ export async function deriveSolanaKeypair({
       publicKeyBytes: hexToBytes(node.publicKey),
     };
   } catch (error: any) {
+    // Log the error for debugging purposes, but rethrow it to be handled/tracked by the caller.
+
     logger.error({ error }, 'Error deriving keypair');
     throw new Error(error);
   }

--- a/packages/snap/src/core/utils/errors.test.ts
+++ b/packages/snap/src/core/utils/errors.test.ts
@@ -40,9 +40,12 @@ describe('errors', () => {
           }),
         },
       });
-      expect(mockLogger.warn).toHaveBeenCalledWith('Failed track error', {
-        error: trackingError,
-      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        {
+          error: trackingError,
+        },
+        'Failed to track error',
+      );
     });
 
     it('tracks errors', async () => {

--- a/packages/snap/src/core/utils/errors.test.ts
+++ b/packages/snap/src/core/utils/errors.test.ts
@@ -1,23 +1,74 @@
 import { expect } from '@jest/globals';
-import { SnapError } from '@metamask/snaps-sdk';
+import { SnapError, UserRejectedRequestError } from '@metamask/snaps-sdk';
 
-import { withCatchAndThrowSnapError } from './errors';
+import { trackError, withCatchAndThrowSnapError } from './errors';
 import logger from './logger';
 
 // Mock the logger to avoid actual console output during tests
 jest.mock('./logger', () => ({
   error: jest.fn(),
+  warn: jest.fn(),
 }));
 
-describe('errors', () => {
-  const mockLogger = logger as jest.Mocked<typeof logger>;
+const setupTest = () => {
+  jest.clearAllMocks();
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+  const mockSnapRequest = jest.fn();
+  (globalThis as any).snap = {
+    request: mockSnapRequest,
+  };
+
+  return { mockSnapRequest, mockLogger: logger as jest.Mocked<typeof logger> };
+};
+
+describe('errors', () => {
+  describe('trackError', () => {
+    it('does not throw if error tracking fails', async () => {
+      const { mockLogger, mockSnapRequest } = setupTest();
+
+      const originalError = new Error('Test error');
+      const trackingError = new Error('Tracking failed');
+      mockSnapRequest.mockRejectedValue(trackingError);
+
+      expect(await trackError(originalError)).toBeUndefined();
+
+      expect(mockSnapRequest).toHaveBeenCalledWith({
+        method: 'snap_trackError',
+        params: {
+          error: expect.objectContaining({
+            message: originalError.message,
+          }),
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith('Failed track error', {
+        error: trackingError,
+      });
+    });
+
+    it('tracks errors', async () => {
+      const { mockLogger, mockSnapRequest } = setupTest();
+
+      const originalError = new Error('Test error');
+      mockSnapRequest.mockResolvedValue('tracked-error-id');
+
+      expect(await trackError(originalError)).toBe('tracked-error-id');
+
+      expect(mockSnapRequest).toHaveBeenCalledWith({
+        method: 'snap_trackError',
+        params: {
+          error: expect.objectContaining({
+            message: originalError.message,
+          }),
+        },
+      });
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('handle', () => {
     it('returns the result when the function succeeds', async () => {
+      const { mockLogger } = setupTest();
+
       const mockFn = jest.fn().mockResolvedValue('success');
 
       const result = await withCatchAndThrowSnapError(mockFn);
@@ -28,6 +79,8 @@ describe('errors', () => {
     });
 
     it('handles and re-throws errors as SnapError', async () => {
+      const { mockLogger } = setupTest();
+
       const originalError = new Error('Test error');
       const mockFn = jest.fn().mockRejectedValue(originalError);
 
@@ -40,6 +93,8 @@ describe('errors', () => {
     });
 
     it('logs errors with the correct scope and error details', async () => {
+      const { mockLogger } = setupTest();
+
       const originalError = new Error('Test error');
       const mockFn = jest.fn().mockRejectedValue(originalError);
 
@@ -61,6 +116,8 @@ describe('errors', () => {
     });
 
     it('handles non-Error objects and converts them to SnapError', async () => {
+      const { mockLogger } = setupTest();
+
       const nonErrorValue = 'string error';
       const mockFn = jest.fn().mockRejectedValue(nonErrorValue);
 
@@ -75,6 +132,8 @@ describe('errors', () => {
     });
 
     it('handles null and undefined errors', async () => {
+      const { mockLogger } = setupTest();
+
       const mockFn = jest.fn().mockRejectedValue(null);
 
       await expect(withCatchAndThrowSnapError(mockFn)).rejects.toThrow(
@@ -101,6 +160,8 @@ describe('errors', () => {
     });
 
     it('handles async functions that return different types', async () => {
+      const { mockLogger } = setupTest();
+
       const testCases = [
         { value: 42, type: 'number' },
         { value: { key: 'value' }, type: 'object' },
@@ -120,6 +181,8 @@ describe('errors', () => {
     });
 
     it('handles functions that throw different error types', async () => {
+      const { mockLogger } = setupTest();
+
       const errorTypes = [
         new TypeError('Type error'),
         new ReferenceError('Reference error'),
@@ -148,6 +211,8 @@ describe('errors', () => {
     });
 
     it('includes error stack trace in the logged error', async () => {
+      const { mockLogger } = setupTest();
+
       const originalError = new Error('Test error');
       originalError.stack = 'Error: Test error\n    at test.js:1:1';
       const mockFn = jest.fn().mockRejectedValue(originalError);
@@ -165,6 +230,8 @@ describe('errors', () => {
     });
 
     it('handles functions that throw promises', async () => {
+      const { mockLogger } = setupTest();
+
       const rejectedPromise = Promise.reject(new Error('Promise error'));
       const mockFn = jest.fn().mockImplementation(async () => rejectedPromise);
 
@@ -172,6 +239,20 @@ describe('errors', () => {
         SnapError,
       );
 
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not track errors when shouldTrackError returns false', async () => {
+      const { mockLogger, mockSnapRequest } = setupTest();
+
+      const originalError = new UserRejectedRequestError();
+      const mockFn = jest.fn().mockRejectedValue(originalError);
+
+      await expect(withCatchAndThrowSnapError(mockFn)).rejects.toThrow(
+        UserRejectedRequestError,
+      );
+
+      expect(mockSnapRequest).not.toHaveBeenCalled();
       expect(mockLogger.error).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/snap/src/core/utils/errors.ts
+++ b/packages/snap/src/core/utils/errors.ts
@@ -62,7 +62,7 @@ export const trackError = async (
       },
     });
   } catch (trackingError) {
-    logger.warn('Failed track error', { error: trackingError });
+    logger.warn({ error: trackingError }, 'Failed to track error');
     return undefined;
   }
 };

--- a/packages/snap/src/core/utils/errors.ts
+++ b/packages/snap/src/core/utils/errors.ts
@@ -16,6 +16,7 @@ import {
   SnapError,
   MethodNotSupportedError,
   UserRejectedRequestError,
+  getJsonError,
 } from '@metamask/snaps-sdk';
 
 import logger from './logger';
@@ -50,12 +51,36 @@ export function isSnapRpcError(error: Error): boolean {
   return errors.some((errType) => error instanceof errType);
 }
 
+export const trackError = async (
+  error: unknown,
+): Promise<string | undefined> => {
+  try {
+    return await snap.request({
+      method: 'snap_trackError',
+      params: {
+        error: getJsonError(error),
+      },
+    });
+  } catch (trackingError) {
+    logger.warn('Failed track error', { error: trackingError });
+    return undefined;
+  }
+};
+
+const shouldTrackError = (error: Error): boolean => {
+  return !(error instanceof UserRejectedRequestError);
+};
+
 export const withCatchAndThrowSnapError = async <ResponseT>(
   fn: () => Promise<ResponseT>,
 ): Promise<ResponseT> => {
   try {
     return await fn();
   } catch (errorInstance: any) {
+    if (shouldTrackError(errorInstance)) {
+      await trackError(errorInstance);
+    }
+
     const error = isSnapRpcError(errorInstance)
       ? errorInstance
       : new SnapError(errorInstance);

--- a/packages/snap/src/core/validation/validators.ts
+++ b/packages/snap/src/core/validation/validators.ts
@@ -54,7 +54,7 @@ export function validateResponse<Params, TStruct extends Struct<any>>(
     assert(response, struct);
   } catch (error) {
     throw new SnapError('Invalid Response', {
-      data: { cause: getJsonError(error as Error) },
+      data: { cause: getJsonError(error) },
     });
   }
 }

--- a/packages/snap/src/core/validation/validators.ts
+++ b/packages/snap/src/core/validation/validators.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-throw-literal */
 import {
+  getJsonError,
   InvalidParamsError,
   SnapError,
   UnauthorizedError,
@@ -52,6 +53,8 @@ export function validateResponse<Params, TStruct extends Struct<any>>(
   try {
     assert(response, struct);
   } catch (error) {
-    throw new SnapError('Invalid Response') as unknown as Error;
+    throw new SnapError('Invalid Response', {
+      data: { cause: getJsonError(error as Error) },
+    });
   }
 }

--- a/packages/snap/src/entities/instructions/instructions.test.ts
+++ b/packages/snap/src/entities/instructions/instructions.test.ts
@@ -1,8 +1,16 @@
 import { address, type Rpc, type SolanaRpcApi } from '@solana/kit';
 
 import { MOCK_EXECUTION_SCENARIO_SEND_SPL_TOKEN } from '../../core/services/signer/mocks/scenarios/sendSplToken';
+import { trackError } from '../../core/utils/errors';
 import type { InstructionParseResult } from './instructions';
-import { extractInstructionsFromUnknownBase64String } from './instructions';
+import {
+  extractInstructionsFromUnknownBase64String,
+  parseInstruction,
+} from './instructions';
+
+jest.mock('../../core/utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 describe('extractInstructionsFromBase64String', () => {
   let mockRpc: Rpc<SolanaRpcApi>;
@@ -119,5 +127,27 @@ describe('extractInstructionsFromBase64String', () => {
     );
 
     expect(result).toStrictEqual(expectedInstructionParseResults);
+  });
+
+  it('tracks instruction parsing failures', () => {
+    const result = parseInstruction({
+      programAddress: address('11111111111111111111111111111112'),
+      accounts: [],
+      data: new Uint8Array([1, 2, 3]),
+    } as any);
+
+    expect(result).toStrictEqual({
+      type: 'Unknown',
+      encoded: expect.objectContaining({
+        programAddress: address('11111111111111111111111111111112'),
+        dataBase58: expect.any(String),
+      }),
+      parsed: null,
+    });
+    expect(trackError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Unsupported program address',
+      }),
+    );
   });
 });

--- a/packages/snap/src/entities/instructions/instructions.ts
+++ b/packages/snap/src/entities/instructions/instructions.ts
@@ -165,6 +165,7 @@ import type {
   SolanaInstruction,
   SolanaTransaction,
 } from '../../core/types/solana';
+import { trackError } from '../../core/utils/errors';
 import type { Base64Struct } from '../../core/validation/structs';
 import {
   identifySecp256Instruction,
@@ -591,6 +592,9 @@ export const parseInstruction = (
       parsed,
     };
   } catch (error) {
+    /* eslint-disable-next-line no-void */
+    void trackError(error);
+
     return {
       type: 'Unknown',
       encoded,

--- a/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.test.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.test.tsx
@@ -267,3 +267,148 @@ describe('render', () => {
     });
   });
 });
+
+describe('render tracking', () => {
+  const setupTest = async () => {
+    const trackError = jest.fn().mockResolvedValue('tracked-error-id');
+    const calculateFee = jest.fn().mockReturnValue({
+      totalFee: 5000n,
+    });
+    const createInterface = jest.fn().mockResolvedValue('interface-id');
+    const getPreferences = jest.fn().mockResolvedValue({
+      locale: 'en',
+      currency: 'usd',
+      useExternalPricingData: true,
+      useSecurityAlerts: true,
+      simulateOnChainActions: true,
+    });
+    const showDialog = jest.fn().mockResolvedValue('dialog-result');
+    const updateInterface = jest.fn().mockResolvedValue(undefined);
+    const extractInstructionsFromUnknownBase64String = jest
+      .fn()
+      .mockResolvedValue([{}]);
+    const extractDestinationAddress = jest.fn();
+    const nameResolutionService = {
+      resolveAddress: jest.fn().mockResolvedValue(null),
+    };
+    const priceApiClient = {
+      getMultipleSpotPrices: jest.fn(),
+    };
+    const transactionScanService = {
+      scanTransaction: jest.fn(),
+    };
+    const state = {
+      setKey: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest.doMock('../../../../core/utils/errors', () => ({
+      trackError,
+    }));
+    jest.doMock('../../../../core/fees', () => ({
+      FeeCalculator: {
+        calculateFee,
+      },
+    }));
+    jest.doMock('../../../../core/utils/interface', () => ({
+      CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME:
+        'confirmation-interface',
+      createInterface,
+      getPreferences,
+      showDialog,
+      updateInterface,
+    }));
+    jest.doMock('./ConfirmTransactionRequest', () => ({
+      ConfirmTransactionRequest: () => null,
+    }));
+    jest.doMock('../../../../entities', () => ({
+      extractInstructionsFromUnknownBase64String,
+    }));
+    jest.doMock('../../utils/extractDestinationAddress', () => ({
+      extractDestinationAddress,
+    }));
+    jest.doMock('../../../../snapContext', () => ({
+      connection: {
+        getRpc: jest.fn().mockReturnValue({}),
+      },
+      nameResolutionService,
+      priceApiClient,
+      state,
+      transactionScanService,
+    }));
+
+    (globalThis as any).snap = {
+      request: jest.fn().mockResolvedValue(undefined),
+    };
+
+    let render:
+      | ((
+          incomingContext: ConfirmTransactionRequestContext,
+        ) => Promise<unknown>)
+      | undefined;
+    jest.isolateModules(() => {
+      ({ render } = jest.requireActual('./render'));
+    });
+
+    if (!render) {
+      throw new Error('Failed to load render');
+    }
+
+    return {
+      render,
+      trackError,
+      calculateFee,
+      extractDestinationAddress,
+      nameResolutionService,
+      priceApiClient,
+      transactionScanService,
+    };
+  };
+
+  it('tracks confirmation fallbacks', async () => {
+    const {
+      render,
+      trackError,
+      calculateFee,
+      extractDestinationAddress,
+      nameResolutionService,
+      priceApiClient,
+      transactionScanService,
+    } = await setupTest();
+
+    const destinationExtractError = new Error('Destination failed');
+    const destinationDomainError = new Error('Domain failed');
+    const pricesError = new Error('Prices failed');
+    const feeError = new Error('Fee failed');
+    const scanError = new Error('Scan failed');
+
+    extractDestinationAddress.mockImplementation(() => {
+      throw destinationExtractError;
+    });
+    nameResolutionService.resolveAddress
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(destinationDomainError);
+    priceApiClient.getMultipleSpotPrices.mockRejectedValue(pricesError);
+    calculateFee.mockImplementation(() => {
+      throw feeError;
+    });
+    transactionScanService.scanTransaction.mockRejectedValue(scanError);
+
+    await expect(
+      render({
+        method: SolMethod.SignAndSendTransaction,
+        scope: Network.Mainnet,
+        transaction: 'transaction',
+        account: {
+          address: 'BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP',
+        },
+        origin: 'https://metamask.io',
+      } as unknown as ConfirmTransactionRequestContext),
+    ).resolves.toBe('dialog-result');
+
+    expect(trackError).toHaveBeenCalledWith(destinationExtractError);
+    expect(trackError).toHaveBeenCalledWith(pricesError);
+    expect(trackError).toHaveBeenCalledWith(feeError);
+    expect(trackError).toHaveBeenCalledWith(scanError);
+    expect(trackError).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
+++ b/packages/snap/src/features/confirmation/views/ConfirmTransactionRequest/render.tsx
@@ -4,6 +4,7 @@ import { Network, Networks } from '../../../../core/constants/solana';
 import { FeeCalculator } from '../../../../core/fees';
 import { SOL_IMAGE_SVG } from '../../../../core/test/mocks/solana-image-svg';
 import { lamportsToSol } from '../../../../core/utils/conversion';
+import { trackError } from '../../../../core/utils/errors';
 import {
   CONFIRM_SIGN_AND_SEND_TRANSACTION_INTERFACE_NAME,
   createInterface,
@@ -87,16 +88,18 @@ export async function render(
     connection.getRpc(context.scope),
     context.transaction,
   )
-    .then((instructions) => {
+    .then(async (instructions) => {
       context.advanced.instructions = instructions;
 
       try {
         context.destinationAddress = extractDestinationAddress(instructions);
-      } catch {
+      } catch (error) {
+        await trackError(error);
         context.destinationAddress = null;
       }
     })
-    .catch((error) => {
+    .catch(async (error) => {
+      await trackError(error);
       logger.error(error);
       context.advanced.instructions = [];
     });
@@ -147,7 +150,8 @@ export async function render(
         .then((domain) => {
           updatedContext1.destinationDomain = domain;
         })
-        .catch(() => {
+        .catch(async (error) => {
+          await trackError(error);
           updatedContext1.destinationDomain = null;
         })
     : Promise.resolve();
@@ -161,7 +165,8 @@ export async function render(
           updatedContext1.tokenPrices = prices;
           updatedContext1.tokenPricesFetchStatus = 'fetched';
         })
-        .catch(() => {
+        .catch(async (error) => {
+          await trackError(error);
           updatedContext1.tokenPricesFetchStatus = 'error';
         })
     : Promise.resolve().then(() => {
@@ -175,7 +180,8 @@ export async function render(
   try {
     const { totalFee } = FeeCalculator.calculateFee(context.transaction);
     feeEstimatedInSol = lamportsToSol(totalFee).toString();
-  } catch {
+  } catch (error) {
+    await trackError(error);
     feeEstimatedInSol = null;
   }
   updatedContext1.feeEstimatedInSol = feeEstimatedInSol;
@@ -218,7 +224,8 @@ export async function render(
         updatedContext2.scan = scan;
         updatedContext2.scanFetchStatus = scan ? 'fetched' : 'error';
       })
-      .catch(() => {
+      .catch(async (error) => {
+        await trackError(error);
         updatedContext2.scan = null;
         updatedContext2.scanFetchStatus = 'error';
       });

--- a/packages/snap/src/features/send/render.test.tsx
+++ b/packages/snap/src/features/send/render.test.tsx
@@ -29,11 +29,24 @@ import { EXPECTED_NATIVE_SOL_TRANSFER_DATA } from '../../core/test/mocks/transac
 import { TEST_ORIGIN } from '../../core/test/utils';
 import type { Preferences } from '../../core/types/snap';
 import { buildUrl } from '../../core/utils/buildUrl';
-import { configProvider } from '../../snapContext';
-import { DEFAULT_SEND_CONTEXT } from './render';
+import { trackError } from '../../core/utils/errors';
+import {
+  accountsService,
+  assetsService,
+  configProvider,
+  connection,
+  priceApiClient,
+  state,
+} from '../../snapContext';
+import { DEFAULT_SEND_CONTEXT, renderSend } from './render';
 import { Send } from './Send';
 import { type SendContext, SendCurrencyType, SendFormNames } from './types';
 import { TransactionConfirmationNames } from './views/TransactionConfirmation/TransactionConfirmation';
+
+jest.mock('../../core/utils/errors', () => ({
+  ...jest.requireActual('../../core/utils/errors'),
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
 
 const solanaKeyringAccounts = [
   MOCK_SOLANA_KEYRING_ACCOUNT_0,
@@ -470,5 +483,144 @@ describe('Send', () => {
       message: expect.stringMatching(/At path: account/u),
       stack: expect.any(String),
     });
+  });
+});
+
+describe('Send tracking', () => {
+  const setupTest = () => {
+    const originalAssetsGetAll = assetsService.getAll;
+    const originalAssetsGetAssetsMetadata = assetsService.getAssetsMetadata;
+    const originalAccountsGetAll = accountsService.getAll;
+    const originalConnectionGetRpc = connection.getRpc;
+    const originalPriceGetMultipleSpotPrices =
+      priceApiClient.getMultipleSpotPrices;
+    const originalStateGetKey = state.getKey;
+    const originalStateSetKey = state.setKey;
+
+    const mockedTrackError = jest.mocked(trackError);
+    mockedTrackError.mockClear();
+
+    const snapRequest = jest
+      .fn()
+      .mockImplementation(async ({ method }: any) => {
+        if (method === 'snap_getPreferences') {
+          return Promise.resolve({
+            locale: 'en',
+            currency: 'usd',
+            useExternalPricingData: true,
+          });
+        }
+
+        if (method === 'snap_createInterface') {
+          return Promise.resolve('interface-id');
+        }
+
+        if (method === 'snap_updateInterface') {
+          return Promise.resolve(undefined);
+        }
+
+        if (method === 'snap_dialog') {
+          return Promise.resolve('dialog-result');
+        }
+
+        if (method === 'snap_scheduleBackgroundEvent') {
+          return Promise.resolve(undefined);
+        }
+
+        throw new Error(`Unexpected snap.request call: ${method}`);
+      });
+
+    assetsService.getAll = jest.fn().mockResolvedValue([
+      {
+        assetType: KnownCaip19Id.SolMainnet,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        symbol: 'SOL',
+        decimals: 9,
+        rawAmount: '1',
+        uiAmount: '1',
+      },
+    ]);
+    assetsService.getAssetsMetadata = jest.fn();
+    accountsService.getAll = jest
+      .fn()
+      .mockResolvedValue([MOCK_SOLANA_KEYRING_ACCOUNT_0]);
+    const rentExemptionSend = jest.fn();
+    connection.getRpc = jest.fn().mockReturnValue({
+      getMinimumBalanceForRentExemption: jest.fn().mockReturnValue({
+        send: rentExemptionSend,
+      }),
+    });
+    priceApiClient.getMultipleSpotPrices = jest.fn();
+    state.getKey = jest.fn().mockResolvedValue(undefined);
+    state.setKey = jest.fn().mockResolvedValue(undefined);
+
+    (globalThis as any).snap = {
+      request: snapRequest,
+    };
+
+    return {
+      trackError: mockedTrackError,
+      assetsService,
+      connection,
+      priceApiClient,
+      cleanup: () => {
+        assetsService.getAll = originalAssetsGetAll;
+        assetsService.getAssetsMetadata = originalAssetsGetAssetsMetadata;
+        accountsService.getAll = originalAccountsGetAll;
+        connection.getRpc = originalConnectionGetRpc;
+        priceApiClient.getMultipleSpotPrices =
+          originalPriceGetMultipleSpotPrices;
+        state.getKey = originalStateGetKey;
+        state.setKey = originalStateSetKey;
+      },
+    };
+  };
+
+  it('tracks initialization fetch failures', async () => {
+    const {
+      trackError: trackErrorMock,
+      assetsService: assetsServiceMock,
+      connection: connectionMock,
+      priceApiClient: priceApiClientMock,
+      cleanup,
+    } = setupTest();
+
+    try {
+      const metadataError = new Error('Metadata failed');
+      const pricesError = new Error('Prices failed');
+      const rentError = new Error('Rent failed');
+
+      jest
+        .mocked(assetsServiceMock.getAssetsMetadata)
+        .mockRejectedValue(metadataError);
+      jest
+        .mocked(priceApiClientMock.getMultipleSpotPrices)
+        .mockRejectedValue(pricesError);
+      jest.mocked(connectionMock.getRpc).mockReturnValue({
+        getMinimumBalanceForRentExemption: jest.fn().mockReturnValue({
+          send: jest.fn().mockRejectedValue(rentError),
+        }),
+      } as any);
+
+      await expect(
+        renderSend({
+          request: {
+            params: {
+              scope: Network.Mainnet,
+              account: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+            },
+          },
+        } as any),
+      ).resolves.toBe('dialog-result');
+
+      expect(trackErrorMock).toHaveBeenCalledWith(metadataError);
+      expect(trackErrorMock).toHaveBeenCalledWith(pricesError);
+      expect(trackErrorMock).toHaveBeenCalledWith(rentError);
+      expect(trackErrorMock).toBeCalledTimes(3);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/packages/snap/src/features/send/render.tsx
+++ b/packages/snap/src/features/send/render.tsx
@@ -5,6 +5,7 @@ import { assert } from '@metamask/superstruct';
 import { KnownCaip19Id, Network, Networks } from '../../core/constants/solana';
 import type { UnencryptedStateValue } from '../../core/services/state/State';
 import { lamportsToSol } from '../../core/utils/conversion';
+import { trackError } from '../../core/utils/errors';
 import {
   createInterface,
   getPreferences,
@@ -124,7 +125,10 @@ export const renderSend: OnRpcRequestHandler = async ({ request }) => {
         imageUrl: null,
       };
     })
-    .catch(() => null);
+    .catch(async (error) => {
+      await trackError(error);
+      return null;
+    });
 
   let tokenPricesPromise;
 
@@ -138,7 +142,8 @@ export const renderSend: OnRpcRequestHandler = async ({ request }) => {
         };
         context.tokenPricesFetchStatus = 'fetched';
       })
-      .catch(() => {
+      .catch(async (error) => {
+        await trackError(error);
         context.tokenPricesFetchStatus = 'error';
       });
   } else {
@@ -153,7 +158,8 @@ export const renderSend: OnRpcRequestHandler = async ({ request }) => {
       context.minimumBalanceForRentExemptionSol =
         lamportsToSol(balance).toString();
     })
-    .catch(() => {
+    .catch(async (error) => {
+      await trackError(error);
       // Do nothing, the value set on default context will be used.
     });
 

--- a/packages/snap/src/features/send/views/SendForm/events.test.ts
+++ b/packages/snap/src/features/send/views/SendForm/events.test.ts
@@ -1,5 +1,6 @@
 import { lamports } from '@solana/kit';
 import BigNumber from 'bignumber.js';
+import type { Preferences } from 'src/core/types/snap';
 
 import {
   KnownCaip19Id,
@@ -17,18 +18,19 @@ import { eventHandlers } from './events';
 
 jest.mock('../../../../core/utils/interface');
 
-describe('SendForm events', () => {
-  const mockId = 'test-id';
-  const mockAccount = MOCK_SOLANA_KEYRING_ACCOUNT_0;
-  const mockToAddress = 'destination-address';
-  const mockBalanceInSol = '1.5'; // 1.5 SOL
-  const mockSolPrice = '20'; // $20 per SOL
-  const mockBaseFeeInLamports = lamports(5000n); // 0.000005 SOL
-  const mockPriorityFeeInLamports = lamports(4n); //  Integer(450 * 10000n / MICRO_LAMPORTS_PER_LAMPORTS)
-  const mockMinimumBalanceForRentExemptionSol = '0.002';
-  const mockMinimumBalanceForRentExemptionLamports = solToLamports(
-    mockMinimumBalanceForRentExemptionSol,
-  );
+const mockId = 'test-id';
+const mockAccount = MOCK_SOLANA_KEYRING_ACCOUNT_0;
+const mockToAddress = 'destination-address';
+const mockBalanceInSol = '1.5'; // 1.5 SOL
+const mockSolPrice = '20'; // $20 per SOL
+const mockBaseFeeInLamports = lamports(5000n); // 0.000005 SOL
+const mockPriorityFeeInLamports = lamports(4n); //  Integer(450 * 10000n / MICRO_LAMPORTS_PER_LAMPORTS)
+const mockMinimumBalanceForRentExemptionSol = '0.002';
+const mockMinimumBalanceForRentExemptionLamports = solToLamports(
+  mockMinimumBalanceForRentExemptionSol,
+);
+
+const setupTest = (overrides: Partial<SendContext> = {}): SendContext => {
   const baseContext: SendContext = {
     fromAccountId: mockAccount.id,
     toAddress: mockToAddress,
@@ -104,12 +106,27 @@ describe('SendForm events', () => {
     loading: true,
   };
 
+  return {
+    ...baseContext,
+    ...overrides,
+    accounts: overrides.accounts ?? baseContext.accounts,
+    assets: overrides.assets ?? baseContext.assets,
+    balances: overrides.balances ?? baseContext.balances,
+    preferences: {
+      ...baseContext.preferences,
+      ...overrides.preferences,
+    },
+    tokenPrices: overrides.tokenPrices ?? baseContext.tokenPrices,
+    validation: overrides.validation ?? baseContext.validation,
+  };
+};
+
+describe('SendForm events', () => {
   describe('onSwapCurrencyButtonClick', () => {
     it('swaps the currency type', async () => {
-      const context: SendContext = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.TOKEN,
-      };
+      });
 
       await eventHandlers[SendFormNames.SwapCurrencyButton]({
         id: mockId,
@@ -120,11 +137,10 @@ describe('SendForm events', () => {
     });
 
     it('does not update the amount if it is empty', async () => {
-      const context: SendContext = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.TOKEN,
         amount: '',
-      };
+      });
 
       await eventHandlers[SendFormNames.SwapCurrencyButton]({
         id: mockId,
@@ -135,11 +151,10 @@ describe('SendForm events', () => {
     });
 
     it('updates the amount if it is not empty', async () => {
-      const context: SendContext = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.TOKEN,
         amount: '1',
-      };
+      });
 
       await eventHandlers[SendFormNames.SwapCurrencyButton]({
         id: mockId,
@@ -162,10 +177,9 @@ describe('SendForm events', () => {
     });
 
     it('calculates max amount in SOL correctly', async () => {
-      const context: SendContext = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.TOKEN,
-      };
+      });
 
       await eventHandlers[SendFormNames.MaxAmountButton]({
         id: mockId,
@@ -192,8 +206,7 @@ describe('SendForm events', () => {
     });
 
     it('calculates max amount in SOL correctly including rounding', async () => {
-      const context: SendContext = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.TOKEN,
         balances: {
           [mockAccount.id]: {
@@ -204,7 +217,7 @@ describe('SendForm events', () => {
           },
         },
         minimumBalanceForRentExemptionSol: '0.00089088',
-      };
+      });
 
       await eventHandlers[SendFormNames.MaxAmountButton]({
         id: mockId,
@@ -229,10 +242,9 @@ describe('SendForm events', () => {
     });
 
     it('calculates max amount in FIAT correctly', async () => {
-      const context = {
-        ...baseContext,
+      const context = setupTest({
         currencyType: SendCurrencyType.FIAT,
-      };
+      });
 
       await eventHandlers[SendFormNames.MaxAmountButton]({
         id: mockId,
@@ -258,5 +270,116 @@ describe('SendForm events', () => {
         }),
       );
     });
+  });
+});
+
+describe('SendForm event tracking', () => {
+  const setupTrackingTest = async () => {
+    const trackError = jest.fn().mockResolvedValue('tracked-error-id');
+    const updateInterfaceMock = jest.fn().mockResolvedValue(undefined);
+    const configProvider = {
+      get: jest.fn().mockReturnValue({
+        staticApi: {
+          baseUrl: 'https://static.example.com',
+        },
+      }),
+    };
+    const nameResolutionService = {
+      resolveAddress: jest.fn().mockResolvedValue(null),
+    };
+    const priceApiClient = {
+      getMultipleSpotPrices: jest.fn(),
+    };
+
+    jest.doMock('../../../../core/utils/errors', () => ({
+      trackError,
+    }));
+    jest.doMock('../../../../core/utils/interface', () => ({
+      resolveInterface: jest.fn(),
+      SEND_FORM_INTERFACE_NAME: 'send-form',
+      updateInterface: updateInterfaceMock,
+    }));
+    jest.doMock('../../Send', () => ({
+      Send: () => null,
+    }));
+    jest.doMock('../../../../snapContext', () => ({
+      configProvider,
+      keyring: {
+        getAccountOrThrow: jest
+          .fn()
+          .mockResolvedValue(MOCK_SOLANA_KEYRING_ACCOUNT_0),
+      },
+      nameResolutionService,
+      priceApiClient,
+      sendSolBuilder: {},
+      sendSplTokenBuilder: {},
+      state: {
+        deleteKey: jest.fn().mockResolvedValue(undefined),
+      },
+    }));
+
+    (globalThis as any).snap = {
+      request: jest.fn().mockResolvedValue(undefined),
+    };
+
+    let isolatedEventHandlers: typeof eventHandlers | undefined;
+    jest.isolateModules(() => {
+      ({ eventHandlers: isolatedEventHandlers } =
+        jest.requireActual('./events'));
+    });
+
+    if (!isolatedEventHandlers) {
+      throw new Error('Failed to load eventHandlers');
+    }
+
+    return {
+      eventHandlers: isolatedEventHandlers,
+      trackError,
+      priceApiClient,
+      updateInterfaceMock,
+    };
+  };
+
+  it('tracks token price failures before confirmation', async () => {
+    const {
+      eventHandlers: isolatedEventHandlers,
+      trackError,
+      priceApiClient,
+      updateInterfaceMock,
+    } = await setupTrackingTest();
+
+    const error = new Error('Spot prices failed');
+    const context = setupTest({
+      accounts: [MOCK_SOLANA_KEYRING_ACCOUNT_0],
+      scope: Network.Mainnet,
+      tokenCaipId: KnownCaip19Id.SolMainnet,
+      assets: [KnownCaip19Id.SolMainnet],
+      balances: {
+        [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
+          [KnownCaip19Id.SolMainnet]: {
+            amount: '2',
+            unit: 'SOL',
+          },
+        },
+      },
+      amount: '1',
+      toAddress: 'FDUGdV6bjhvw5gbirXCvqbTSWK9999kcrZcrHoCQzXJK',
+      feeEstimatedInSol: '0.000005',
+      tokenPrices: {},
+      preferences: {
+        currency: 'usd',
+        useExternalPricingData: true,
+      } as Preferences,
+      selectedTokenMetadata: null,
+    });
+
+    priceApiClient.getMultipleSpotPrices.mockRejectedValue(error);
+
+    await isolatedEventHandlers[SendFormNames.SendButton]({
+      id: 'interface-id',
+      context,
+    });
+
+    expect(trackError).toHaveBeenNthCalledWith(1, error);
   });
 });

--- a/packages/snap/src/features/send/views/SendForm/events.tsx
+++ b/packages/snap/src/features/send/views/SendForm/events.tsx
@@ -10,6 +10,7 @@ import {
   lamportsToSol,
   solToLamports,
 } from '../../../../core/utils/conversion';
+import { trackError } from '../../../../core/utils/errors';
 import { i18n } from '../../../../core/utils/i18n';
 import {
   resolveInterface,
@@ -485,7 +486,10 @@ async function onSendButtonClick({
     priceApiClient
       .getMultipleSpotPrices(context.assets, context.preferences.currency)
       .then((prices) => prices)
-      .catch(() => null),
+      .catch(async (error) => {
+        await trackError(error);
+        return null;
+      }),
   ]);
 
   updatedContext.fromDomain = fromDomain;

--- a/packages/snap/src/features/send/views/TransactionConfirmation/events.test.tsx
+++ b/packages/snap/src/features/send/views/TransactionConfirmation/events.test.tsx
@@ -1,0 +1,99 @@
+import { KnownCaip19Id, Network } from '../../../../core/constants/solana';
+import { trackError } from '../../../../core/utils/errors';
+import { updateInterface } from '../../../../core/utils/interface';
+import { keyring, state, walletService } from '../../../../snapContext';
+import { SendCurrencyType } from '../../types';
+import { eventHandlers } from './events';
+
+const CONFIRM_BUTTON_NAME = 'transaction-confirmation-submit-button';
+
+jest.mock('../../../../core/utils/errors', () => ({
+  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
+}));
+
+jest.mock('../../../../core/utils/interface', () => ({
+  resolveInterface: jest.fn(),
+  SEND_FORM_INTERFACE_NAME: 'send-form',
+  updateInterface: jest.fn(),
+}));
+
+jest.mock('../../Send', () => ({
+  Send: () => null,
+}));
+
+jest.mock('./TransactionConfirmation', () => ({
+  TransactionConfirmationNames: {
+    BackButton: 'transaction-confirmation-back-button',
+    CancelButton: 'transaction-confirmation-cancel-button',
+    ConfirmButton: 'transaction-confirmation-submit-button',
+  },
+}));
+
+jest.mock('../../../../snapContext', () => ({
+  keyring: {
+    getAccountOrThrow: jest.fn(),
+  },
+  state: {
+    deleteKey: jest.fn(),
+  },
+  walletService: {
+    signAndSendTransaction: jest.fn(),
+  },
+}));
+
+const setupTest = () => {
+  jest.clearAllMocks();
+  (globalThis as any).snap = {
+    request: jest.fn().mockResolvedValue(undefined),
+  };
+  (keyring.getAccountOrThrow as jest.Mock).mockResolvedValue({
+    id: 'account-id',
+    address: 'BLw3RweJmfbTapJRgnPRvd962YDjFYAnVGd1p5hmZ5tP',
+  });
+  (updateInterface as jest.Mock).mockResolvedValue(undefined);
+  (state.deleteKey as jest.Mock).mockResolvedValue(undefined);
+};
+
+describe('TransactionConfirmation events', () => {
+  it('tracks submission errors and still renders the failure stage', async () => {
+    setupTest();
+
+    const error = new Error('Submission failed');
+
+    (walletService.signAndSendTransaction as jest.Mock).mockRejectedValue(
+      error,
+    );
+
+    await eventHandlers[CONFIRM_BUTTON_NAME]({
+      id: 'interface-id',
+      context: {
+        scope: Network.Mainnet,
+        fromAccountId: 'account-id',
+        feeEstimatedInSol: '0.000005',
+        transactionMessage: 'transaction-message',
+        tokenCaipId: KnownCaip19Id.SolMainnet,
+        currencyType: SendCurrencyType.TOKEN,
+        tokenPrices: {},
+        assets: [],
+        balances: {},
+        preferences: {
+          locale: 'en',
+          currency: 'usd',
+        },
+      } as any,
+    });
+
+    expect(trackError).toHaveBeenCalledWith(error);
+    expect(updateInterface).toHaveBeenLastCalledWith(
+      'interface-id',
+      null,
+      expect.objectContaining({
+        stage: 'transaction-failure',
+        transaction: {
+          result: 'failure',
+          signature: null,
+        },
+      }),
+    );
+  });
+});

--- a/packages/snap/src/features/send/views/TransactionConfirmation/events.tsx
+++ b/packages/snap/src/features/send/views/TransactionConfirmation/events.tsx
@@ -1,5 +1,6 @@
 import { METAMASK_ORIGIN } from '../../../../core/constants/solana';
 import { ScheduleBackgroundEventMethod } from '../../../../core/handlers/onCronjob/backgroundEvents/ScheduleBackgroundEventMethod';
+import { trackError } from '../../../../core/utils/errors';
 import {
   resolveInterface,
   SEND_FORM_INTERFACE_NAME,
@@ -149,6 +150,7 @@ async function onConfirmButtonClick({
 
     signature = response.signature;
   } catch (error) {
+    await trackError(error);
     logger.error({ error }, 'Error submitting request');
   }
 


### PR DESCRIPTION
Added suppressed error tracking for non-blocking failure paths by wiring trackError into the affected send/confirmation flows and instruction parsing fallback, without changing the user-facing fallback behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes in existing catch/fallback paths; user flows and return values stay the same, with user rejections excluded from tracking.
> 
> **Overview**
> Adds centralized **`trackError`** that reports failures to MetaMask via `snap_trackError` (with safe fallback if tracking itself fails), and wires it into paths that already **swallow** errors—NFT metadata, analytics, transaction scan/mapping/fetch, subscriptions, cron refresh handlers, send/confirmation UI fallbacks, instruction parsing, keyring address resolution, and related services.
> 
> **`withCatchAndThrowSnapError`** now calls `trackError` before rethrowing, but **skips** `UserRejectedRequestError`. Invalid response validation attaches the struct cause via `getJsonError`. User-visible fallback behavior (null returns, empty arrays, failure stages) is unchanged; the manifest **shasum** is updated for the rebuilt bundle.
> 
> Tests assert `trackError` is invoked across these failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1190cc83f8c190ca335f2a6cc892c991a5e0662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->