### PR TITLE
docs: add migration notice for internal-snaps monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/internal-snaps"><code>internal-snaps</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over. Also, please re-open PRs that are under active development in the <code>internal-snaps</code> repo.</p></td></tr></table>
+
 # Solana Wallet Snap Monorepo
 
 ![Hero Illustration](docs/hero.png)


### PR DESCRIPTION
Add the standard migration banner to `README.md` warning that this repo is being migrated to [`internal-snaps`](https://github.com/MetaMask/internal-snaps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **prominent migration banner** at the top of `README.md` directing contributors to the MetaMask `internal-snaps` monorepo.
> 
> The notice asks people not to commit here during the migration and to reopen in-flight PRs in `internal-snaps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0831ee3422c9f4b2b040e666d9069287438f228b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->