### PR TITLE
Revert "2.11.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-wallet-snap-monorepo",
-  "version": "2.11.0",
+  "version": "2.10.0",
   "private": true,
   "description": "",
   "homepage": "https://github.com/MetaMask/snap-solana-wallet#readme",

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.11.0]
-
 ### Added
 
 - Implement keyring type and methods to V2 ([#606](https://github.com/MetaMask/snap-solana-wallet/pull/606))

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/solana-wallet-snap",
-  "version": "2.11.0",
+  "version": "2.10.0",
   "description": "A Solana wallet Snap.",
   "repository": {
     "type": "git",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.0",
+  "version": "2.10.0",
   "description": "Manage Solana using MetaMask",
   "proposedName": "Solana",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "xICEHrfvt4angv2DjjjwKrGNlzqyjahXOxm6WmhvL6U=",
+    "shasum": "fdWx8g4QQ+OzWlzGQARfmkIG/0U+JvegNhc2QWYiCfw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Reverts MetaMask/snap-solana-wallet#629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog rollback with no runtime code changes in the diff.
> 
> **Overview**
> Reverts the **2.11.0** release tagging from #629 by restoring package and Snap versions to **2.10.0** in the monorepo root, `packages/snap/package.json`, and `snap.manifest.json`.
> 
> Updates the manifest **source shasum** to match the bundle at the reverted version. In `CHANGELOG.md`, removes the `## [2.11.0]` section so the keyring V2 notes remain under **`[Unreleased]`** instead of a shipped release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9dedce62b10e8d01dbbf969bb41b0179ccbc537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->