### PR TITLE
fix: evaluated positive or negative `balanceDiff` to put transactions in `from` or `to`

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Reconcile snap package with monorepo template ([#628](https://github.com/MetaMask/snap-solana-wallet/pull/628))
   - Require Node.js `>=20`
 
+### Fixed
+
+- Fixed small USDC-to-SOL swaps being incorrectly displayed as sends in Solana activity ([#632](https://github.com/MetaMask/snap-solana-wallet/pull/632))
+
 ## [3.0.0]
 
 ### Added

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "VN4aDapRDvXKljuAXN4JalZVaHZZiniM8YUaCf3B7hQ=",
+    "shasum": "AuQwfRdQXZnVvKa+6895O/T8kSGd942tEohTw/4XsqA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/services/transactions/TransactionMapper.test.ts
+++ b/packages/snap/src/core/services/transactions/TransactionMapper.test.ts
@@ -1,4 +1,4 @@
-import { address as asAddress } from '@solana/kit';
+import { address as asAddress, lamports } from '@solana/kit';
 
 import { KnownCaip19Id, Network, Networks } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNT_0 } from '../../test/mocks/solana-keyring-accounts';
@@ -27,6 +27,46 @@ import { TransactionMapper } from './TransactionMapper';
 jest.mock('../../utils/errors', () => ({
   trackError: jest.fn().mockResolvedValue('tracked-error-id'),
 }));
+
+type WithTransactionMapperCallback<ReturnValue> = (payload: {
+  transactionMapper: TransactionMapper;
+  mockTokenHelper: jest.Mocked<Pick<TokenHelper, 'amountToUiAmountForMint'>>;
+  mockAssetsService: jest.Mocked<Pick<AssetsService, 'getAssetsMetadata'>>;
+}) => Promise<ReturnValue> | ReturnValue;
+
+/**
+ * Wraps tests by creating a fresh TransactionMapper and fresh mocks.
+ *
+ * @param testFunction - The test body receiving the TransactionMapper and relevant mocks.
+ * @returns The return value of the callback.
+ */
+async function withTransactionMapper<ReturnValue>(
+  testFunction: WithTransactionMapperCallback<ReturnValue>,
+): Promise<ReturnValue> {
+  const mockTokenHelper: jest.Mocked<
+    Pick<TokenHelper, 'amountToUiAmountForMint'>
+  > = {
+    amountToUiAmountForMint: jest.fn().mockResolvedValue('1'),
+  };
+
+  const mockAssetsService: jest.Mocked<
+    Pick<AssetsService, 'getAssetsMetadata'>
+  > = {
+    getAssetsMetadata: jest.fn().mockResolvedValue({}),
+  };
+
+  const transactionMapper = new TransactionMapper(
+    mockTokenHelper as unknown as TokenHelper,
+    mockAssetsService as unknown as AssetsService,
+    logger,
+  );
+
+  return await testFunction({
+    transactionMapper,
+    mockTokenHelper,
+    mockAssetsService,
+  });
+}
 
 describe('TransactionMapper', () => {
   let transactionMapper: TransactionMapper;
@@ -214,6 +254,142 @@ describe('TransactionMapper', () => {
       });
     });
 
+    it.each([
+      {
+        description: 'less than',
+        receivedLamports: 1n,
+        expectedAmount: '0.000000001',
+      },
+      {
+        description: 'equal to',
+        receivedLamports: 5000n,
+        expectedAmount: '0.000005',
+      },
+      {
+        description: 'greater than',
+        receivedLamports: 10000n,
+        expectedAmount: '0.00001',
+      },
+    ])(
+      'maps incoming native SOL for the fee payer when the received amount is $description the transaction fee',
+      async ({ receivedLamports, expectedAmount }) => {
+        await withTransactionMapper(
+          async ({ transactionMapper: freshTransactionMapper }) => {
+            const feeLamports = 5000n;
+            const feePayerPreBalance = 1000000n;
+            const counterpartyPreBalance = receivedLamports;
+            const [feePayerAddress, counterpartyAddress] =
+              EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction.message.accountKeys;
+
+            const result = await freshTransactionMapper.mapRpcTransaction(
+              {
+                ...EXPECTED_NATIVE_SOL_TRANSFER_DATA,
+                meta: {
+                  ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.meta,
+                  // eslint-disable-next-line id-denylist
+                  err: null,
+                  fee: lamports(feeLamports),
+                  preBalances: [
+                    lamports(feePayerPreBalance),
+                    lamports(counterpartyPreBalance),
+                    lamports(1n),
+                  ],
+                  postBalances: [
+                    lamports(
+                      feePayerPreBalance - feeLamports + receivedLamports,
+                    ),
+                    lamports(0n),
+                    lamports(1n),
+                  ],
+                },
+                transaction: {
+                  ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction,
+                  message: {
+                    ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction.message,
+                    instructions: [],
+                  },
+                },
+              },
+              mockAccount,
+              Network.Mainnet,
+            );
+
+            expect(result).toMatchObject({
+              type: 'receive',
+              from: [
+                {
+                  address: counterpartyAddress,
+                  asset: {
+                    amount: expectedAmount,
+                    fungible: true,
+                    type: Networks[Network.Mainnet].nativeToken.caip19Id,
+                    unit: Networks[Network.Mainnet].nativeToken.symbol,
+                  },
+                },
+              ],
+              to: [
+                {
+                  address: feePayerAddress,
+                  asset: {
+                    amount: expectedAmount,
+                    fungible: true,
+                    type: Networks[Network.Mainnet].nativeToken.caip19Id,
+                    unit: Networks[Network.Mainnet].nativeToken.symbol,
+                  },
+                },
+              ],
+            });
+          },
+        );
+      },
+    );
+
+    it('does not treat a transaction-fee-only SOL balance decrease as a native SOL transfer', async () => {
+      await withTransactionMapper(
+        async ({ transactionMapper: freshTransactionMapper }) => {
+          const feeLamports = 5000n;
+          const feePayerPreBalance = 1000000n;
+
+          const result = await freshTransactionMapper.mapRpcTransaction(
+            {
+              ...EXPECTED_NATIVE_SOL_TRANSFER_DATA,
+              meta: {
+                ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.meta,
+                // eslint-disable-next-line id-denylist
+                err: null,
+                fee: lamports(feeLamports),
+                preBalances: [
+                  lamports(feePayerPreBalance),
+                  lamports(0n),
+                  lamports(1n),
+                ],
+                postBalances: [
+                  lamports(feePayerPreBalance - feeLamports),
+                  lamports(0n),
+                  lamports(1n),
+                ],
+              },
+              transaction: {
+                ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction,
+                message: {
+                  ...EXPECTED_NATIVE_SOL_TRANSFER_DATA.transaction.message,
+                  instructions: [],
+                },
+              },
+            },
+            mockAccount,
+            Network.Mainnet,
+          );
+
+          expect(result).toMatchObject({
+            type: 'unknown',
+            from: [],
+            to: [],
+          });
+        },
+      );
+    });
+
     it('maps native SOL transfers - failure', async () => {
       const result = await transactionMapper.mapRpcTransaction(
         {
@@ -367,6 +543,98 @@ describe('TransactionMapper', () => {
         ],
       });
     });
+
+    it.each([
+      {
+        description: 'less than',
+        receivedLamports: 1n,
+        expectedAmount: '0.000000001',
+      },
+      {
+        description: 'equal to',
+        receivedLamports: 5000n,
+        expectedAmount: '0.000005',
+      },
+      {
+        description: 'greater than',
+        receivedLamports: 10000n,
+        expectedAmount: '0.00001',
+      },
+    ])(
+      'classifies an SPL token to native SOL transaction as a swap when incoming SOL is $description the transaction fee',
+      async ({ receivedLamports, expectedAmount }) => {
+        await withTransactionMapper(
+          async ({
+            mockTokenHelper: freshMockTokenHelper,
+            transactionMapper: freshTransactionMapper,
+          }) => {
+            freshMockTokenHelper.amountToUiAmountForMint.mockResolvedValue(
+              '0.01',
+            );
+
+            const feeLamports = 5000n;
+            const feePayerPreBalance = 1000000n;
+            const counterpartyPreBalance = 2039280n;
+            const [feePayerAddress] =
+              EXPECTED_SEND_USDC_TRANSFER_DATA.transaction.message.accountKeys;
+
+            const result = await freshTransactionMapper.mapRpcTransaction(
+              {
+                ...EXPECTED_SEND_USDC_TRANSFER_DATA,
+                meta: {
+                  ...EXPECTED_SEND_USDC_TRANSFER_DATA.meta,
+                  // eslint-disable-next-line id-denylist
+                  err: null,
+                  fee: lamports(feeLamports),
+                  preBalances: [
+                    lamports(feePayerPreBalance),
+                    lamports(counterpartyPreBalance),
+                    lamports(2039280n),
+                    lamports(934087680n),
+                  ],
+                  postBalances: [
+                    lamports(
+                      feePayerPreBalance - feeLamports + receivedLamports,
+                    ),
+                    lamports(counterpartyPreBalance - receivedLamports),
+                    lamports(2039280n),
+                    lamports(934087680n),
+                  ],
+                },
+              },
+              mockAccount,
+              Network.Devnet,
+            );
+
+            expect(result).toMatchObject({
+              type: 'swap',
+              from: [
+                {
+                  address: feePayerAddress,
+                  asset: {
+                    amount: '0.01',
+                    fungible: true,
+                    type: `${Network.Devnet}/token:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`,
+                    unit: '',
+                  },
+                },
+              ],
+              to: [
+                {
+                  address: feePayerAddress,
+                  asset: {
+                    amount: expectedAmount,
+                    fungible: true,
+                    type: Networks[Network.Devnet].nativeToken.caip19Id,
+                    unit: Networks[Network.Devnet].nativeToken.symbol,
+                  },
+                },
+              ],
+            });
+          },
+        );
+      },
+    );
 
     it('maps SPL token transfers - as a sender to self', async () => {
       const result = await transactionMapper.mapRpcTransaction(
@@ -726,15 +994,15 @@ describe('TransactionMapper', () => {
               amount: '0.01',
             },
           },
-          {
-            address: 'DtMUkCoeyzs35B6EpQQxPyyog6TRwXxV1W1Acp8nWBNa',
-            asset: {
-              amount: '0.000000008',
-              fungible: true,
-              type: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
-              unit: 'SOL',
-            },
-          },
+          // {
+          //   address: 'DtMUkCoeyzs35B6EpQQxPyyog6TRwXxV1W1Acp8nWBNa',
+          //   asset: {
+          //     amount: '0.000000008',
+          //     fungible: true,
+          //     type: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+          //     unit: 'SOL',
+          //   },
+          // },
         ],
         to: [
           {
@@ -744,6 +1012,15 @@ describe('TransactionMapper', () => {
               type: `${Network.Mainnet}/token:HaMv3cdfDW6357yjpDur6kb6w52BUPJrMJpR76tjpump`,
               unit: '',
               amount: '2583.728601',
+            },
+          },
+          {
+            address: 'DtMUkCoeyzs35B6EpQQxPyyog6TRwXxV1W1Acp8nWBNa',
+            asset: {
+              amount: '0.000000008',
+              fungible: true,
+              type: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+              unit: 'SOL',
             },
           },
         ],

--- a/packages/snap/src/core/services/transactions/TransactionMapper.ts
+++ b/packages/snap/src/core/services/transactions/TransactionMapper.ts
@@ -363,10 +363,9 @@ export class TransactionMapper {
       const amount = balanceDiffSol.absoluteValue().toString();
 
       /**
-       * If the pre-balance is greater than the post-balance, it means that the account
-       * has lost SOL, so it's a sender.
+       * If the balance diff (preBalance-postBalance-fee) is positive, it means that the account is a sender.
        */
-      if (preBalance.isGreaterThan(postBalance)) {
+      if (balanceDiffSol.isPositive()) {
         from.push({
           address,
           asset: {
@@ -379,10 +378,9 @@ export class TransactionMapper {
       }
 
       /**
-       * If the pre-balance is less than the post-balance, it means that the account
-       * has gained SOL, so it's a receiver.
+       * If the balance diff (preBalance-postBalance-fee) is negative, it means that the account is a receiver.
        */
-      if (preBalance.isLessThan(postBalance)) {
+      if (balanceDiffSol.isNegative()) {
         to.push({
           address,
           asset: {


### PR DESCRIPTION
# Description

Fixes incorrect transaction direction and type detection when the fee payer receives an amount of SOL that is less than or equal to the transaction fee.
Previously, native transfer direction was determined using the raw pre and post transaction balances.
For a USDC-to-SOL swap, the fee payer’s balance can still decrease when the received SOL is smaller than the fee.
This caused the incoming SOL to be classified as outgoing and could prevent the transaction from being identified as a swap.

The mapper now determines direction from the fee-adjusted balance difference:

- Positive difference -> outgoing SOL
- Negative difference -> incoming SOL
- Zero difference -> fee-only balance change, not a transfer

Fixes MetaMask/metamask-extension#43164


## Changes

- Use the fee-adjusted SOL balance difference to determine native transfer direction.
- Ignore SOL balance decreases caused exclusively by transaction fees.
- Update the existing swap expectation to reflect the correct native SOL direction.
- Add tests covering incoming SOL amounts that are:
  - Less than the transaction fee
  - Equal to the transaction fee
  - Greater than the transaction fee
- Add equivalent coverage for SPL-token-to-native-SOL swaps.
- Use fresh mapper dependencies in the new parameterized tests to prevent mock state from leaking between cases.

## Testing
- Added native SOL transfer boundary tests around the transaction fee.
- Added a fee-only transaction test.
- Added SPL-token-to-SOL swap classification tests for all fee boundary cases.

### Before
<img width="487" height="326" alt="WPN-1223  Before" src="https://github.com/user-attachments/assets/c56dfa41-d248-483d-b3ba-a09c16e41a71" />

https://github.com/user-attachments/assets/8268aaec-b119-4411-8699-ec542f505db6

### After
<img width="994" height="287" alt="WPN-1223  After" src="https://github.com/user-attachments/assets/2848f028-32c7-4b83-ac7b-4a1ed7e2911c" />

https://github.com/user-attachments/assets/c5560390-234e-446c-8c29-b4d055a94276



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction type/direction logic for all native SOL balance parsing in activity; wrong edge cases could misclassify sends, receives, or swaps.
> 
> **Overview**
> Fixes Solana activity mislabeling **small USDC→SOL swaps as sends** when the fee payer’s net SOL change is dominated by the transaction fee.
> 
> **`TransactionMapper`** now classifies native SOL movement from the **fee-adjusted** balance difference (`pre − post − fee` for the fee payer): positive → `from`, negative → `to`, zero → skip (fee-only, not a transfer). Direction no longer uses raw pre/post balances alone.
> 
> Tests add a `withTransactionMapper` helper and cover incoming SOL at fee boundaries, fee-only txs, and SPL→SOL swap classification; one swap fixture expectation is updated for correct SOL leg ordering. Changelog and snap manifest shasum are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0895f9d99a0b0c51ad2cbcd1e5dc6ed69176c5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->