### PR TITLE
feat(WPN-1476): route Solana asset reads through CoreAssetsAdapter (Lane B - PR 4b)

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "Z8MRP494zWU14vlSqGPWu+lZOzU3WW41yBt6fKNQiYY=",
+    "shasum": "ypPQKjnOeCNwZSWmNYJ/ZLGA5gX1a5ZgWTyWNiSdb7o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/services/assets/AssetsService.test.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.test.ts
@@ -2,6 +2,7 @@ import { KeyringEvent } from '@metamask/keyring-api';
 import { emitSnapKeyringEvent } from '@metamask/keyring-snap-sdk';
 import { cloneDeep } from 'lodash';
 
+import type { AssetEntity } from '../../../entities';
 import type { ICache } from '../../caching/ICache';
 import { InMemoryCache } from '../../caching/InMemoryCache';
 import { MOCK_NFTS_LIST_RESPONSE_MAPPED } from '../../clients/nft-api/mocks/mockNftsListResponseMapped';
@@ -113,6 +114,7 @@ describe('AssetsService', () => {
       configProvider: mockConfigProvider,
       snapAssetsAdapter,
       coreAssetsAdapter: mockCoreAssetsAdapter,
+      accountsService: mockAccountsService,
       tokenApiClient: mockTokenApiClient,
       tokenPricesService: mockTokenPricesService,
       nftApiClient: mockNftApiClient,
@@ -632,23 +634,47 @@ describe('AssetsService', () => {
   });
 
   describe('getAccountAssetByID', () => {
-    it('returns the matching asset when present', async () => {
+    it('routes fungible assets through CoreAssetsAdapter', async () => {
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetByID')
+        .mockResolvedValueOnce(MOCK_ASSET_ENTITY_1);
 
       const asset = await assetsService.getAccountAssetByID(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
         MOCK_ASSET_ENTITY_1.assetType,
       );
 
+      expect(mockCoreAssetsAdapter.getAccountAssetByID).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_ASSET_ENTITY_1.assetType,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+      );
       expect(asset).toStrictEqual(MOCK_ASSET_ENTITY_1);
     });
 
-    it('returns null when the asset is missing', async () => {
+    it('routes NFT assets through SnapAssetsAdapter', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const snapSpy = jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetByID')
+        .mockResolvedValueOnce(null);
+
+      await assetsService.getAccountAssetByID(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        nftAssetType,
+      );
+
+      expect(snapSpy).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        nftAssetType,
+      );
+      expect(mockCoreAssetsAdapter.getAccountAssetByID).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the fungible asset is missing from Core', async () => {
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce([]);
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetByID')
+        .mockResolvedValueOnce(null);
 
       const asset = await assetsService.getAccountAssetByID(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
@@ -660,51 +686,120 @@ describe('AssetsService', () => {
   });
 
   describe('getAccountAssetsByIDs', () => {
-    it('returns a record keyed by asset ID', async () => {
+    it('routes fungible and NFT asset IDs to the correct adapters', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetsByIDs')
+        .mockResolvedValueOnce({
+          [MOCK_ASSET_ENTITY_0.assetType]: MOCK_ASSET_ENTITY_0,
+        });
+      jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetsByIDs')
+        .mockResolvedValueOnce({
+          [nftAssetType]: null,
+        });
 
       const assets = await assetsService.getAccountAssetsByIDs(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
-        [MOCK_ASSET_ENTITY_0.assetType, MOCK_ASSET_ENTITY_1.assetType],
+        [MOCK_ASSET_ENTITY_0.assetType, nftAssetType],
       );
 
-      expect(assets).toStrictEqual({
-        [MOCK_ASSET_ENTITY_0.assetType]: MOCK_ASSET_ENTITY_0,
-        [MOCK_ASSET_ENTITY_1.assetType]: MOCK_ASSET_ENTITY_1,
-      });
-    });
-
-    it('returns null entries for missing assets', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0]);
-
-      const assets = await assetsService.getAccountAssetsByIDs(
+      expect(mockCoreAssetsAdapter.getAccountAssetsByIDs).toHaveBeenCalledWith(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
-        [MOCK_ASSET_ENTITY_0.assetType, MOCK_ASSET_ENTITY_1.assetType],
+        [MOCK_ASSET_ENTITY_0.assetType],
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
       );
-
+      expect(snapAssetsAdapter.getAccountAssetsByIDs).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        [nftAssetType],
+      );
       expect(assets).toStrictEqual({
         [MOCK_ASSET_ENTITY_0.assetType]: MOCK_ASSET_ENTITY_0,
-        [MOCK_ASSET_ENTITY_1.assetType]: null,
+        [nftAssetType]: null,
       });
     });
   });
 
   describe('getAccountAssetsByScope', () => {
-    it('filters account assets to the requested scope', async () => {
+    it('merges fungible Core assets with Snap-owned NFT assets for the scope', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const nftAsset = {
+        assetType: nftAssetType,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
+        symbol: 'NFT',
+        decimals: 0,
+        rawAmount: '1',
+        uiAmount: '1',
+      } as AssetEntity;
+
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetsByScope')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0, MOCK_ASSET_ENTITY_1]);
+      jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetsByScope')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_2, nftAsset]);
 
       const assets = await assetsService.getAccountAssetsByScope(
         Network.Mainnet,
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
       );
 
-      expect(assets).toStrictEqual(MOCK_ASSET_ENTITIES);
+      expect(
+        mockCoreAssetsAdapter.getAccountAssetsByScope,
+      ).toHaveBeenCalledWith(
+        Network.Mainnet,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+      );
+      expect(assets).toStrictEqual([
+        MOCK_ASSET_ENTITY_0,
+        MOCK_ASSET_ENTITY_1,
+        nftAsset,
+      ]);
+    });
+  });
+
+  describe('getAccountAssetsForAllActiveScopes', () => {
+    it('merges fungible Core assets with Snap-owned NFT assets across active scopes', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const nftAsset = {
+        assetType: nftAssetType,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
+        symbol: 'NFT',
+        decimals: 0,
+        rawAmount: '1',
+        uiAmount: '1',
+      } as AssetEntity;
+
+      jest
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetsByScope')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0]);
+      jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetsForAllActiveScopes')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_1, nftAsset]);
+
+      const assets = await assetsService.getAccountAssetsForAllActiveScopes(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+      );
+
+      expect(
+        mockCoreAssetsAdapter.getAccountAssetsByScope,
+      ).toHaveBeenCalledWith(
+        Network.Mainnet,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+      );
+      expect(assets).toStrictEqual([MOCK_ASSET_ENTITY_0, nftAsset]);
     });
   });
 });

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-returns */
 import type {
   FungibleAssetMarketData,
   FungibleAssetMetadata,
@@ -9,19 +8,21 @@ import { parseCaipAssetType } from '@metamask/utils';
 import type { AssetEntity, SolanaKeyringAccount } from '../../../entities';
 import type { NftApiClient } from '../../clients/nft-api/NftApiClient';
 import type { TokenApiClient } from '../../clients/token-api-client/TokenApiClient';
-import { SolanaCaip19Tokens } from '../../constants/solana';
 import type {
-  Caip10Address,
   NativeCaipAssetType,
   NftCaipAssetType,
   TokenCaipAssetType,
 } from '../../constants/solana';
+import { SolanaCaip19Tokens } from '../../constants/solana';
+import type { Caip10Address } from '../../constants/solana';
 import { createPrefixedLogger } from '../../utils/logger';
 import type { ILogger } from '../../utils/logger';
+import type { AccountsService } from '../accounts/AccountsService';
 import type { ConfigProvider } from '../config';
 import type { TokenPricesService } from '../token-prices/TokenPrices';
 import type { CoreAssetsAdapter } from './adapters/CoreAssetsAdapter';
 import { SnapAssetsAdapter } from './adapters/SnapAssetsAdapter';
+import { isSnapOwnedAsset } from './snapOwnedAssets';
 import type { AssetMetadata, NonFungibleAssetMetadata } from './types';
 
 export class AssetsService {
@@ -31,8 +32,9 @@ export class AssetsService {
 
   readonly #snapAdapter: SnapAssetsAdapter;
 
-  /** Reserved for migration routing in a follow-up PR; not used for reads yet. */
   readonly #coreAssetsAdapter: CoreAssetsAdapter;
+
+  readonly #accountsService: AccountsService;
 
   readonly #tokenPricesService: TokenPricesService;
 
@@ -45,6 +47,7 @@ export class AssetsService {
     configProvider,
     snapAssetsAdapter,
     coreAssetsAdapter,
+    accountsService,
     tokenApiClient,
     tokenPricesService,
     nftApiClient,
@@ -53,6 +56,7 @@ export class AssetsService {
     configProvider: ConfigProvider;
     snapAssetsAdapter: SnapAssetsAdapter;
     coreAssetsAdapter: CoreAssetsAdapter;
+    accountsService: AccountsService;
     tokenApiClient: TokenApiClient;
     tokenPricesService: TokenPricesService;
     nftApiClient: NftApiClient;
@@ -61,9 +65,14 @@ export class AssetsService {
     this.#configProvider = configProvider;
     this.#snapAdapter = snapAssetsAdapter;
     this.#coreAssetsAdapter = coreAssetsAdapter;
+    this.#accountsService = accountsService;
     this.#tokenApiClient = tokenApiClient;
     this.#tokenPricesService = tokenPricesService;
     this.#nftApiClient = nftApiClient;
+  }
+
+  async #solanaChainIds(): Promise<string[]> {
+    return this.#configProvider.getActiveNetworks();
   }
 
   #splitAssetsByType(assetTypes: CaipAssetType[]) {
@@ -139,7 +148,7 @@ export class AssetsService {
         imageUrl: nftMetadata.imageUrl,
         description: nftMetadata.description,
         fungible: false as const,
-        isPossibleSpam: false, // FIXME: The isSpam should be part of the NFT item response, not balance, otherwise we can't get it here
+        isPossibleSpam: false,
         attributes: Object.fromEntries(
           nftMetadata.attributes.map(
             (attr: { key: string; value: string | number }) => [
@@ -153,7 +162,7 @@ export class AssetsService {
           address: nftMetadata.onchainCollectionAddress as Caip10Address,
           symbol: nftMetadata.collectionSymbol,
           tokenCount: nftMetadata.collectionCount,
-          creator: '' as Caip10Address, // FIXME: There can be more than one creator
+          creator: '' as Caip10Address,
           imageUrl: nftMetadata.collectionImageUrl ?? '',
         },
       };
@@ -169,23 +178,17 @@ export class AssetsService {
   ): Promise<Record<CaipAssetType, AssetMetadata | null>> {
     this.#logger.log('Fetching metadata for assets', assetTypes);
 
-    const { nativeAssetTypes, tokenAssetTypes, nftAssetTypes } =
+    const { nativeAssetTypes, tokenAssetTypes } =
       this.#splitAssetsByType(assetTypes);
 
-    const [
-      nativeTokensMetadata,
-      tokensMetadata,
-      // nftMetadata,
-    ] = await Promise.all([
+    const [nativeTokensMetadata, tokensMetadata] = await Promise.all([
       this.#getNativeTokensMetadata(nativeAssetTypes),
       this.#tokenApiClient.getTokensMetadata(tokenAssetTypes),
-      // this.#getNftsMetadata(nftAssetTypes),
     ]);
 
     return {
       ...nativeTokensMetadata,
       ...tokensMetadata,
-      // ...nftMetadata,
     };
   }
 
@@ -216,13 +219,6 @@ export class AssetsService {
     return this.#snapAdapter.saveMany(assets);
   }
 
-  /**
-   * Checks if the asset has changed compared to passed assets lookup.
-   *
-   * @param asset - The asset to check.
-   * @param assetsLookup - The lookup table to check against.
-   * @returns True if the asset has changed, false otherwise.
-   */
   static hasChanged(asset: AssetEntity, assetsLookup: AssetEntity[]): boolean {
     return SnapAssetsAdapter.hasChanged(asset, assetsLookup);
   }
@@ -231,55 +227,114 @@ export class AssetsService {
     return this.#snapAdapter.getAll();
   }
 
-  /**
-   * Returns a single account asset by CAIP-19 ID, or `null` if missing.
-   *
-   * @param accountId - Keyring account ID.
-   * @param assetId - CAIP-19 asset ID.
-   */
   async getAccountAssetByID(
     accountId: string,
-    assetId: string,
+    assetId: CaipAssetType,
   ): Promise<AssetEntity | null> {
-    return this.#snapAdapter.getAccountAssetByID(accountId, assetId);
+    if (isSnapOwnedAsset(assetId)) {
+      return this.#snapAdapter.getAccountAssetByID(accountId, assetId);
+    }
+
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return null;
+    }
+
+    return this.#coreAssetsAdapter.getAccountAssetByID(
+      accountId,
+      assetId,
+      account.address,
+    );
   }
 
-  /**
-   * Returns account assets for the given CAIP-19 IDs, keyed by asset ID.
-   * Missing assets are `null`.
-   *
-   * @param accountId - Keyring account ID.
-   * @param assetIds - CAIP-19 asset IDs to resolve.
-   */
   async getAccountAssetsByIDs(
     accountId: string,
     assetIds: string[],
   ): Promise<Record<string, AssetEntity | null>> {
-    return this.#snapAdapter.getAccountAssetsByIDs(accountId, assetIds);
+    if (assetIds.length === 0) {
+      return {};
+    }
+
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return Object.fromEntries(assetIds.map((assetId) => [assetId, null]));
+    }
+
+    const snapOwnedIds = assetIds.filter(isSnapOwnedAsset);
+    const fungibleIds = assetIds.filter(
+      (assetId) => !isSnapOwnedAsset(assetId),
+    );
+
+    const [fungibleResults, snapResults] = await Promise.all([
+      fungibleIds.length > 0
+        ? this.#coreAssetsAdapter.getAccountAssetsByIDs(
+            accountId,
+            fungibleIds,
+            account.address,
+          )
+        : Promise.resolve({}),
+      snapOwnedIds.length > 0
+        ? this.#snapAdapter.getAccountAssetsByIDs(accountId, snapOwnedIds)
+        : Promise.resolve({}),
+    ]);
+
+    return { ...snapResults, ...fungibleResults };
   }
 
-  /**
-   * Returns controller-backed assets for an account on the given Solana scope.
-   *
-   * @param scope - CAIP-2 chain ID to filter results.
-   * @param accountId - Keyring account ID.
-   */
   async getAccountAssetsByScope(
     scope: CaipChainId,
     accountId: string,
   ): Promise<AssetEntity[]> {
-    return this.#snapAdapter.getAccountAssetsByScope(scope, accountId);
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return [];
+    }
+
+    const [fungibleAssets, snapAssets] = await Promise.all([
+      this.#coreAssetsAdapter.getAccountAssetsByScope(
+        scope,
+        accountId,
+        account.address,
+      ),
+      this.#snapAdapter.getAccountAssetsByScope(scope, accountId),
+    ]);
+
+    const nftAssets = snapAssets.filter((asset) =>
+      isSnapOwnedAsset(asset.assetType),
+    );
+
+    return [...fungibleAssets, ...nftAssets];
   }
 
-  /**
-   * Returns assets for an account across all active Solana networks.
-   *
-   * @param accountId - Keyring account ID.
-   */
   async getAccountAssetsForAllActiveScopes(
     accountId: string,
   ): Promise<AssetEntity[]> {
-    return this.#snapAdapter.getAccountAssetsForAllActiveScopes(accountId);
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return [];
+    }
+
+    const chainIds = (await this.#solanaChainIds()) as CaipChainId[];
+    const relevantChainIds = chainIds.filter((chainId) =>
+      account.scopes.includes(chainId),
+    );
+
+    const fungibleByScope = await Promise.all(
+      relevantChainIds.map((scope) =>
+        this.#coreAssetsAdapter.getAccountAssetsByScope(
+          scope,
+          accountId,
+          account.address,
+        ),
+      ),
+    );
+    const snapAssets =
+      await this.#snapAdapter.getAccountAssetsForAllActiveScopes(accountId);
+    const nftAssets = snapAssets.filter((asset) =>
+      isSnapOwnedAsset(asset.assetType),
+    );
+
+    return [...fungibleByScope.flat(), ...nftAssets];
   }
 
   async findByAccount(account: SolanaKeyringAccount): Promise<AssetEntity[]> {

--- a/packages/snap/src/core/services/assets/index.ts
+++ b/packages/snap/src/core/services/assets/index.ts
@@ -2,4 +2,5 @@ export * from './adapters/CoreAssetsAdapter';
 export * from './adapters/SnapAssetsAdapter';
 export * from './AssetsRepository';
 export * from './AssetsService';
+export * from './snapOwnedAssets';
 export * from './TokenHelper';

--- a/packages/snap/src/core/services/assets/snapOwnedAssets.test.ts
+++ b/packages/snap/src/core/services/assets/snapOwnedAssets.test.ts
@@ -1,0 +1,17 @@
+import { KnownCaip19Id } from '../../constants/solana';
+import { isSnapOwnedAsset } from './snapOwnedAssets';
+
+describe('isSnapOwnedAsset', () => {
+  it('returns true for NFT CAIP-19 asset IDs', () => {
+    expect(
+      isSnapOwnedAsset(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for fungible native and token asset IDs', () => {
+    expect(isSnapOwnedAsset(KnownCaip19Id.SolMainnet)).toBe(false);
+    expect(isSnapOwnedAsset(KnownCaip19Id.UsdcMainnet)).toBe(false);
+  });
+});

--- a/packages/snap/src/core/services/assets/snapOwnedAssets.ts
+++ b/packages/snap/src/core/services/assets/snapOwnedAssets.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns whether an asset remains exclusively managed by the Snap.
+ *
+ * AssetsController does not persist Solana NFT balances. NFT assets must always
+ * be read, synchronized, persisted, and published by the Snap, regardless of
+ * the assets migration stage.
+ *
+ * @param assetId - CAIP-19 asset ID.
+ * @returns Whether the asset is exclusively managed by the Snap.
+ */
+export function isSnapOwnedAsset(assetId: string): boolean {
+  return assetId.includes('/nft:');
+}

--- a/packages/snap/src/features/send/render.test.tsx
+++ b/packages/snap/src/features/send/render.test.tsx
@@ -1,5 +1,6 @@
 import type { CaipAssetType } from '@metamask/keyring-api';
 import { getMockAccount, installSnap } from '@metamask/snaps-jest';
+import type { Json } from '@metamask/utils';
 
 import type { SpotPrices } from '../../core/clients/price-api/types';
 import {
@@ -29,6 +30,7 @@ import { TEST_ORIGIN } from '../../core/test/utils';
 import type { Preferences } from '../../core/types/snap';
 import { buildUrl } from '../../core/utils/buildUrl';
 import { trackError } from '../../core/utils/errors';
+import type { AssetEntity } from '../../entities';
 import {
   accountsService,
   assetsService,
@@ -48,6 +50,13 @@ jest.mock('../../core/utils/errors', () => ({
   trackError: jest.fn().mockResolvedValue('tracked-error-id'),
 }));
 
+const TEST_TOKEN_MINT_1 = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const TEST_TOKEN_MINT_2 = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+const TEST_TOKEN_ASSET_1 =
+  'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as const;
+const TEST_TOKEN_ASSET_2 =
+  'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB' as const;
+
 const solanaKeyringAccounts = [
   MOCK_SOLANA_KEYRING_ACCOUNT_0,
   MOCK_SOLANA_KEYRING_ACCOUNT_1,
@@ -59,14 +68,16 @@ const solanaAccountBalances: Record<string, { amount: string; unit: string }> =
       amount: '0.123456789',
       unit: SOL_SYMBOL,
     },
-    'solana:123456789abcdef/token:address1': {
-      amount: '0.123456789',
-      unit: '',
-    },
-    'solana:123456789abcdef/token:address2': {
-      amount: '0.123456789',
-      unit: '',
-    },
+    'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+      {
+        amount: '0.123456789',
+        unit: '',
+      },
+    'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB':
+      {
+        amount: '0.123456789',
+        unit: '',
+      },
   };
 
 const mockSpotPrices: SpotPrices = {
@@ -96,7 +107,7 @@ const mockSpotPrices: SpotPrices = {
     holderCount: null,
     isMutable: null,
   },
-  'solana:123456789abcdef/token:address1': {
+  'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': {
     id: 'euro-coin',
     price: 200,
     marketCap: 142095635.08509836,
@@ -122,7 +133,7 @@ const mockSpotPrices: SpotPrices = {
     holderCount: null,
     isMutable: null,
   },
-  'solana:123456789abcdef/token:address2': {
+  'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': {
     id: 'usd-coin',
     price: 200,
     marketCap: 55688170578.59265,
@@ -159,14 +170,19 @@ const mockContext: SendContext = {
   tokenCaipId: KnownCaip19Id.SolLocalnet,
   assets: [
     KnownCaip19Id.SolLocalnet,
-    'solana:123456789abcdef/token:address1',
-    'solana:123456789abcdef/token:address2',
+    'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
   ],
   balances: {
     [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: solanaAccountBalances,
     [MOCK_SOLANA_KEYRING_ACCOUNT_1.id]: solanaAccountBalances,
   },
   tokenPrices: mockSpotPrices,
+  tokenPricesFetchStatus: 'fetched',
+  preferences: {
+    ...DEFAULT_SEND_CONTEXT.preferences,
+    useExternalPricingData: false,
+  },
   loading: false,
 };
 
@@ -211,22 +227,24 @@ describe('Send', () => {
         uiAmount: '0.123456789',
       },
       {
-        assetType: 'solana:123456789abcdef/token:address1',
+        assetType:
+          'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
         network: Network.Localnet,
         symbol: 'EURO-COIN',
-        mint: 'address1',
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         pubkey: 'pubkey1',
         decimals: 6,
         rawAmount: '123456789',
         uiAmount: '123.456789',
       },
       {
-        assetType: 'solana:123456789abcdef/token:address2',
+        assetType:
+          'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
         keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
         network: Network.Localnet,
         symbol: 'USDC',
-        mint: 'address2',
+        mint: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
         pubkey: 'pubkey2',
         decimals: 6,
         rawAmount: '123456789',
@@ -245,6 +263,7 @@ describe('Send', () => {
           entropySource: 'alternative',
         },
       },
+      tokenPrices: mockSpotPrices as Json,
       assetEntities: {
         [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: mockAssetEntities,
         [MOCK_SOLANA_KEYRING_ACCOUNT_1.id]: mockAssetEntities,
@@ -256,7 +275,7 @@ describe('Send', () => {
       currency: 'usd',
       hideBalances: false,
       useSecurityAlerts: true,
-      useExternalPricingData: true,
+      useExternalPricingData: false,
       simulateOnChainActions: true,
       useTokenDetection: true,
       batchCheckBalances: true,
@@ -271,12 +290,14 @@ describe('Send', () => {
         unencryptedState: initialState,
         accounts: [
           getMockAccount({
+            id: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
             address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
             selected: true,
             assets: Object.keys(solanaAccountBalances) as CaipAssetType[],
             scopes: [Network.Localnet],
           }),
           getMockAccount({
+            id: MOCK_SOLANA_KEYRING_ACCOUNT_1.id,
             address: MOCK_SOLANA_KEYRING_ACCOUNT_1.address,
             selected: false,
             assets: Object.keys(solanaAccountBalances) as CaipAssetType[],
@@ -288,14 +309,16 @@ describe('Send', () => {
             symbol: 'SOL',
             name: 'Solana',
           },
-          'solana:123456789abcdef/token:address1': {
-            symbol: 'EURO-COIN',
-            name: 'Euro Coin',
-          },
-          'solana:123456789abcdef/token:address2': {
-            symbol: 'USDC',
-            name: 'USDC',
-          },
+          'solana:123456789abcdef/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+            {
+              symbol: 'EURO-COIN',
+              name: 'Euro Coin',
+            },
+          'solana:123456789abcdef/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB':
+            {
+              symbol: 'USDC',
+              name: 'USDC',
+            },
         },
       },
     });
@@ -529,21 +552,27 @@ describe('Send tracking', () => {
         throw new Error(`Unexpected snap.request call: ${method}`);
       });
 
+    const mockSendAssets: AssetEntity[] = [
+      {
+        assetType: KnownCaip19Id.SolMainnet,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        symbol: 'SOL',
+        decimals: 9,
+        rawAmount: '1',
+        uiAmount: '1',
+      },
+    ];
+
     jest
       .spyOn(assetsService, 'getAll')
       .mockImplementation()
-      .mockResolvedValue([
-        {
-          assetType: KnownCaip19Id.SolMainnet,
-          keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
-          network: Network.Mainnet,
-          address: MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
-          symbol: 'SOL',
-          decimals: 9,
-          rawAmount: '1',
-          uiAmount: '1',
-        },
-      ]);
+      .mockResolvedValue(mockSendAssets);
+    jest
+      .spyOn(assetsService, 'getAccountAssetsByScope')
+      .mockImplementation()
+      .mockResolvedValue(mockSendAssets);
     jest.spyOn(assetsService, 'getAssetsMetadata').mockImplementation();
     jest
       .spyOn(accountsService, 'getAll')

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -185,6 +185,7 @@ const assetsService = new AssetsService({
   configProvider,
   snapAssetsAdapter,
   coreAssetsAdapter,
+  accountsService,
   tokenApiClient,
   tokenPricesService,
   nftApiClient,


### PR DESCRIPTION
## Summary
- Route fungible balance reads through `CoreAssetsAdapter` immediately (no feature flags, no stage resolution)
- Keep Snap-owned NFT reads on `SnapAssetsAdapter`; Snap tracking (`fetch`/`saveMany`) unchanged
- Inject `AccountsService` into `AssetsService` for Core adapter account address resolution

## Test plan
- [x] `yarn workspace @metamask/solana-wallet-snap test:core`
- [x] AssetsService tests verify Core path for fungibles and Snap path for NFTs