### PR TITLE
feat(WPN-1476): disable Snap tracking with CoreAssetsAdapter hardcoded (Lane B - PR 5b)

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-solana-wallet.git"
   },
   "source": {
-    "shasum": "ypPQKjnOeCNwZSWmNYJ/ZLGA5gX1a5ZgWTyWNiSdb7o=",
+    "shasum": "WQc7czpO0Kr5fD5MLK7A6XgyBoI+BH6Vevn288QiWag=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/core/services/accounts/AccountsSynchronizer.ts
+++ b/packages/snap/src/core/services/accounts/AccountsSynchronizer.ts
@@ -34,14 +34,12 @@ export class AccountsSynchronizer {
     const assets = (
       await Promise.allSettled(
         accountsToSync.map(async (account) =>
-          this.#assetsService.fetch(account),
+          this.#assetsService.getAccountAssetsForAllActiveScopes(account.id),
         ),
       )
     )
       .map((item) => (item.status === 'fulfilled' ? item.value : []))
       .flat();
-
-    await this.#assetsService.saveMany(assets);
 
     const transactions =
       await this.#transactionsService.fetchAssetsTransactions(assets, {

--- a/packages/snap/src/core/services/assets/AssetsService.test.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.test.ts
@@ -1,4 +1,3 @@
-import { KeyringEvent } from '@metamask/keyring-api';
 import { emitSnapKeyringEvent } from '@metamask/keyring-snap-sdk';
 import { cloneDeep } from 'lodash';
 
@@ -23,7 +22,6 @@ import type { ConfigProvider } from '../config';
 import type { SolanaConnection } from '../connection';
 import { mockLogger } from '../mocks/logger';
 import { createMockConnection } from '../mocks/mockConnection';
-import { MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE } from '../mocks/mockSolanaRpcResponses';
 import type { TokenPricesService } from '../token-prices/TokenPrices';
 import type { CoreAssetsAdapter } from './adapters/CoreAssetsAdapter';
 import { SnapAssetsAdapter } from './adapters/SnapAssetsAdapter';
@@ -105,8 +103,8 @@ describe('AssetsService', () => {
 
     mockCoreAssetsAdapter = {
       getAccountAssetByID: jest.fn(),
-      getAccountAssetsByIDs: jest.fn(),
       getAccountAssetsByScope: jest.fn(),
+      getAccountAssetsByIDs: jest.fn(),
     } as unknown as CoreAssetsAdapter;
 
     assetsService = new AssetsService({
@@ -122,391 +120,34 @@ describe('AssetsService', () => {
   });
 
   describe('fetch', () => {
-    it('fetches native and token assets', async () => {
-      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
-        getBalance: jest.fn().mockReturnValueOnce({
-          send: jest.fn().mockResolvedValue({
-            value: 1000000000, // Native balance on Mainnet
-          }),
-        }),
-        getTokenAccountsByOwner: jest.fn().mockReturnValue({
-          send: jest
-            .fn()
-            .mockResolvedValueOnce({
-              value:
-                MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE.result
-                  .value,
-            })
-            .mockResolvedValue({
-              value: [],
-            }),
-        }),
-      } as any);
+    it('returns an empty array because Snap fungible tracking is disabled', async () => {
+      const fetchSpy = jest.spyOn(snapAssetsAdapter, 'fetch');
 
       const assets = await assetsService.fetch(MOCK_SOLANA_KEYRING_ACCOUNT_0);
 
-      expect(assets).toStrictEqual(MOCK_ASSET_ENTITIES);
-    });
-
-    it('does not fail on individual RPC call failures to fetch native assets', async () => {
-      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
-        getBalance: jest.fn().mockReturnValue({
-          send: jest
-            .fn()
-            .mockRejectedValueOnce(new Error('Error getting balance')),
-        }),
-        getTokenAccountsByOwner: jest.fn().mockReturnValue({
-          send: jest
-            .fn()
-            .mockResolvedValueOnce({
-              value:
-                MOCK_SOLANA_RPC_GET_TOKEN_ACCOUNTS_BY_OWNER_RESPONSE.result
-                  .value,
-            })
-            .mockResolvedValue({
-              value: [],
-            }),
-        }),
-      } as any);
-
-      const assets = await assetsService.fetch(MOCK_SOLANA_KEYRING_ACCOUNT_0);
-
-      expect(assets).toStrictEqual([MOCK_ASSET_ENTITY_1, MOCK_ASSET_ENTITY_2]);
-    });
-
-    it('does not fail on individual RPC call failures to fetch token assets', async () => {
-      jest.spyOn(mockConnection, 'getRpc').mockReturnValue({
-        getBalance: jest.fn().mockReturnValueOnce({
-          send: jest.fn().mockResolvedValue({
-            value: 1000000000, // Native balance on Mainnet
-          }),
-        }),
-        getTokenAccountsByOwner: jest.fn().mockReturnValue({
-          send: jest
-            .fn()
-            .mockRejectedValueOnce(new Error('Error getting token accounts')),
-        }),
-      } as any);
-
-      const assets = await assetsService.fetch(MOCK_SOLANA_KEYRING_ACCOUNT_0);
-
-      expect(assets).toStrictEqual([MOCK_ASSET_ENTITY_0]);
+      expect(assets).toStrictEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('save', () => {
-    it('saves an asset', async () => {
-      const spy = jest
-        .spyOn(assetsService, 'saveMany')
-        .mockResolvedValueOnce(undefined);
+    it('is a no-op because Snap fungible tracking is disabled', async () => {
+      const saveManySpy = jest.spyOn(mockAssetsRepository, 'saveMany');
 
       await assetsService.save(MOCK_ASSET_ENTITY_0);
 
-      expect(spy).toHaveBeenCalledWith([MOCK_ASSET_ENTITY_0]);
+      expect(saveManySpy).not.toHaveBeenCalled();
     });
   });
 
   describe('saveMany', () => {
-    it('delegates to repository for saving assets', async () => {
-      const saveManySpy = jest
-        .spyOn(mockAssetsRepository, 'saveMany')
-        .mockResolvedValue(undefined);
-
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([]);
+    it('is a no-op because Snap fungible tracking is disabled', async () => {
+      const saveManySpy = jest.spyOn(mockAssetsRepository, 'saveMany');
 
       await assetsService.saveMany(MOCK_ASSET_ENTITIES);
 
-      expect(saveManySpy).toHaveBeenCalledWith(MOCK_ASSET_ENTITIES);
-    });
-
-    it('emits event "AccountAssetListUpdated" with ALL assets in added list, and removed assets in removed list', async () => {
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([]);
-
-      const addedAssets = [MOCK_ASSET_ENTITY_0, MOCK_ASSET_ENTITY_1];
-      const removedAssets = [
-        {
-          ...MOCK_ASSET_ENTITY_2,
-          rawAmount: '0',
-        },
-      ];
-
-      await assetsService.saveMany([...addedAssets, ...removedAssets]);
-
-      expect(emitSnapKeyringEvent).toHaveBeenNthCalledWith(
-        1,
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        {
-          assets: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              added: [
-                MOCK_ASSET_ENTITY_0.assetType,
-                MOCK_ASSET_ENTITY_1.assetType,
-              ],
-              removed: [MOCK_ASSET_ENTITY_2.assetType],
-            },
-          },
-        },
-      );
-    });
-
-    it('emits event "AccountAssetListUpdated" when an asset was saved with a zero balance and some more is added', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValueOnce([{ ...MOCK_ASSET_ENTITY_0, rawAmount: '0' }])
-        .mockResolvedValueOnce([{ ...MOCK_ASSET_ENTITY_0, rawAmount: '0' }]);
-
-      await assetsService.saveMany([
-        { ...MOCK_ASSET_ENTITY_0, rawAmount: '0' },
-      ]);
-
-      await assetsService.saveMany([
-        { ...MOCK_ASSET_ENTITY_0, rawAmount: '1000000' },
-      ]);
-
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        {
-          assets: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              added: [MOCK_ASSET_ENTITY_0.assetType],
-              removed: [],
-            },
-          },
-        },
-      );
-    });
-
-    it('emits event "AccountBalancesUpdated" when balances change', async () => {
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([]);
-
-      await assetsService.saveMany(MOCK_ASSET_ENTITIES);
-
-      expect(emitSnapKeyringEvent).toHaveBeenNthCalledWith(
-        2,
-        snap,
-        KeyringEvent.AccountBalancesUpdated,
-        {
-          balances: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              [MOCK_ASSET_ENTITY_0.assetType]: {
-                unit: MOCK_ASSET_ENTITY_0.symbol,
-                amount: MOCK_ASSET_ENTITY_0.uiAmount,
-              },
-              [MOCK_ASSET_ENTITY_1.assetType]: {
-                unit: MOCK_ASSET_ENTITY_1.symbol,
-                amount: MOCK_ASSET_ENTITY_1.uiAmount,
-              },
-              [MOCK_ASSET_ENTITY_2.assetType]: {
-                unit: MOCK_ASSET_ENTITY_2.symbol,
-                amount: MOCK_ASSET_ENTITY_2.uiAmount,
-              },
-            },
-          },
-        },
-      );
-    });
-
-    it('emits event "AccountBalancesUpdated" when native balance goes from non-zero to zero', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValue([{ ...MOCK_ASSET_ENTITY_0, uiAmount: '1234' }]);
-
-      await assetsService.saveMany([{ ...MOCK_ASSET_ENTITY_0, uiAmount: '0' }]);
-
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountBalancesUpdated,
-        {
-          balances: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              [MOCK_ASSET_ENTITY_0.assetType]: {
-                unit: MOCK_ASSET_ENTITY_0.symbol,
-                amount: '0',
-              },
-            },
-          },
-        },
-      );
-    });
-
-    // With isIncremental = false, we do emit events, even when no assets changed
-    it.skip('does not emit events when no assets changed', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValue(MOCK_ASSET_ENTITIES);
-
-      await assetsService.saveMany(MOCK_ASSET_ENTITIES);
-      (emitSnapKeyringEvent as jest.Mock).mockClear();
-
-      await assetsService.saveMany(MOCK_ASSET_ENTITIES);
-
+      expect(saveManySpy).not.toHaveBeenCalled();
       expect(emitSnapKeyringEvent).not.toHaveBeenCalled();
-    });
-
-    it('fetches saved assets before saving new assets to ensure correct change detection', async () => {
-      const callOrder: string[] = [];
-
-      const getAllSpy = jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockImplementation(async () => {
-          callOrder.push('getAll');
-          return [];
-        });
-
-      const saveManySpy = jest
-        .spyOn(mockAssetsRepository, 'saveMany')
-        .mockImplementation(async () => {
-          callOrder.push('saveMany');
-        });
-
-      await assetsService.saveMany(MOCK_ASSET_ENTITIES);
-
-      // Verify that getAll was called before saveMany
-      expect(callOrder).toStrictEqual(['getAll', 'saveMany']);
-      expect(getAllSpy).toHaveBeenCalledTimes(1);
-      expect(saveManySpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('correctly detects new assets when savedAssets is fetched before saving', async () => {
-      // Start with empty state
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([]);
-
-      await assetsService.saveMany([MOCK_ASSET_ENTITY_0]);
-
-      // Should emit AccountAssetListUpdated with the new asset
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        {
-          assets: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              added: [MOCK_ASSET_ENTITY_0.assetType],
-              removed: [],
-            },
-          },
-        },
-      );
-    });
-
-    it('correctly detects assets going from zero to non-zero balance when savedAssets is fetched before saving', async () => {
-      const assetWithZeroBalance = { ...MOCK_ASSET_ENTITY_0, rawAmount: '0' };
-      const assetWithNonZeroBalance = {
-        ...MOCK_ASSET_ENTITY_0,
-        rawAmount: '1000000',
-      };
-
-      // First save with zero balance
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([]);
-      await assetsService.saveMany([assetWithZeroBalance]);
-
-      (emitSnapKeyringEvent as jest.Mock).mockClear();
-
-      // Then save with non-zero balance, but getAll should return the state before this save
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValueOnce([assetWithZeroBalance]);
-      await assetsService.saveMany([assetWithNonZeroBalance]);
-
-      // Should emit AccountAssetListUpdated because asset went from zero to non-zero
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        {
-          assets: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              added: [MOCK_ASSET_ENTITY_0.assetType],
-              removed: [],
-            },
-          },
-        },
-      );
-    });
-
-    // With isIncremental = false, we do emit events, even when no assets changed
-    it.skip('does not incorrectly mark assets as new when they are already in the saved state', async () => {
-      // Mock that the asset already exists in saved state
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0]);
-
-      await assetsService.saveMany([MOCK_ASSET_ENTITY_0]);
-
-      // Should not emit AccountAssetListUpdated since no assets were actually added/removed
-      expect(emitSnapKeyringEvent).not.toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        expect.any(Object),
-      );
-    });
-
-    it('correctly identifies balance changes when savedAssets reflects pre-save state', async () => {
-      const originalAsset = { ...MOCK_ASSET_ENTITY_0, rawAmount: '1000000' };
-      const updatedAsset = {
-        ...MOCK_ASSET_ENTITY_0,
-        rawAmount: '2000000',
-        uiAmount: '2.0',
-      };
-
-      // Mock that original asset exists in saved state
-      jest
-        .spyOn(mockAssetsRepository, 'getAll')
-        .mockResolvedValueOnce([originalAsset]);
-
-      await assetsService.saveMany([updatedAsset]);
-
-      // Should emit AccountBalancesUpdated because balance changed
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountBalancesUpdated,
-        {
-          balances: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              [MOCK_ASSET_ENTITY_0.assetType]: {
-                unit: updatedAsset.symbol,
-                amount: updatedAsset.uiAmount,
-              },
-            },
-          },
-        },
-      );
-    });
-
-    it('does not include native assets in removed array even when they have zero balance', async () => {
-      const nativeAssetWithZeroBalance = {
-        ...MOCK_ASSET_ENTITY_0,
-        rawAmount: '0',
-      };
-      const tokenAssetWithZeroBalance = {
-        ...MOCK_ASSET_ENTITY_1,
-        rawAmount: '0',
-      };
-
-      // Mock that both assets existed with non-zero balance
-      jest.spyOn(mockAssetsRepository, 'getAll').mockResolvedValueOnce([
-        MOCK_ASSET_ENTITY_0, // Native asset with non-zero balance
-        MOCK_ASSET_ENTITY_1, // Token asset with non-zero balance
-      ]);
-
-      await assetsService.saveMany([
-        nativeAssetWithZeroBalance,
-        tokenAssetWithZeroBalance,
-      ]);
-
-      // Should emit AccountAssetListUpdated with only the token asset in the removed array
-      expect(emitSnapKeyringEvent).toHaveBeenCalledWith(
-        snap,
-        KeyringEvent.AccountAssetListUpdated,
-        {
-          assets: {
-            [MOCK_SOLANA_KEYRING_ACCOUNT_0.id]: {
-              added: [MOCK_ASSET_ENTITY_0.assetType],
-              removed: [MOCK_ASSET_ENTITY_1.assetType], // Only token asset, not native
-            },
-          },
-        },
-      );
     });
   });
 

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -192,8 +192,8 @@ export class AssetsService {
     };
   }
 
-  async fetch(account: SolanaKeyringAccount): Promise<AssetEntity[]> {
-    return this.#snapAdapter.fetch(account);
+  async fetch(_account: SolanaKeyringAccount): Promise<AssetEntity[]> {
+    return [];
   }
 
   async fetchAssetsMarketData(
@@ -211,12 +211,12 @@ export class AssetsService {
     return marketData;
   }
 
-  async save(asset: AssetEntity): Promise<void> {
-    await this.saveMany([asset]);
+  async save(_asset: AssetEntity): Promise<void> {
+    // Fungible assets are tracked by Core; Snap persistence is disabled.
   }
 
-  async saveMany(assets: AssetEntity[]): Promise<void> {
-    return this.#snapAdapter.saveMany(assets);
+  async saveMany(_assets: AssetEntity[]): Promise<void> {
+    // Fungible assets are tracked by Core; Snap persistence is disabled.
   }
 
   static hasChanged(asset: AssetEntity, assetsLookup: AssetEntity[]): boolean {

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
@@ -16,28 +16,20 @@ import type {
 } from '../../../entities';
 import { KnownCaip19Id, Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNTS } from '../../test/mocks/solana-keyring-accounts';
-import { trackError } from '../../utils/errors';
 import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
-import type { AssetsService, TokenHelper } from '../assets';
 import type { ConfigProvider } from '../config';
 import { mockLogger } from '../mocks/logger';
 import type { TransactionsService } from '../transactions';
 import { KeyringAccountMonitor } from './KeyringAccountMonitor';
 import type { SubscriptionService } from './SubscriptionService';
 
-jest.mock('../../utils/errors', () => ({
-  trackError: jest.fn().mockResolvedValue('tracked-error-id'),
-}));
-
 describe('KeyringAccountMonitor', () => {
   let keyringAccountMonitor: KeyringAccountMonitor;
   let mockSubscriptionService: SubscriptionService;
   let mockAccountService: AccountsService;
-  let mockAssetsService: AssetsService;
   let mockTransactionsService: TransactionsService;
   let mockAccountsSynchronizer: AccountsSynchronizer;
-  let mockTokenHelper: TokenHelper;
   let mockConfigProvider: ConfigProvider;
 
   const account = MOCK_SOLANA_KEYRING_ACCOUNTS[0];
@@ -124,17 +116,6 @@ describe('KeyringAccountMonitor', () => {
       findByAddress: jest.fn(),
     } as unknown as AccountsService;
 
-    mockAssetsService = {
-      getTokenAccountsByOwnerMultiple: jest.fn(),
-      save: jest.fn(),
-      getAssetsMetadata: jest.fn().mockImplementation((assetType) => ({
-        [assetType]: {
-          symbol: 'USDC',
-          decimals: 6,
-        },
-      })),
-    } as unknown as AssetsService;
-
     mockTransactionsService = {
       fetchLatestSignatures: jest.fn(),
       fetchBySignature: jest.fn(),
@@ -145,11 +126,6 @@ describe('KeyringAccountMonitor', () => {
       synchronize: jest.fn(),
     } as unknown as AccountsSynchronizer;
 
-    mockTokenHelper = {
-      uiAmountToAmountForMint: jest.fn(),
-      amountToUiAmountForMint: jest.fn(),
-    } as unknown as TokenHelper;
-
     mockConfigProvider = {
       getActiveNetworks: jest
         .fn()
@@ -159,10 +135,8 @@ describe('KeyringAccountMonitor', () => {
     keyringAccountMonitor = new KeyringAccountMonitor(
       mockSubscriptionService,
       mockAccountService,
-      mockAssetsService,
       mockTransactionsService,
       mockAccountsSynchronizer,
-      mockTokenHelper,
       mockConfigProvider,
       mockLogger,
     );
@@ -361,23 +335,12 @@ describe('KeyringAccountMonitor', () => {
         params: [account.address, { commitment: 'confirmed' as const }],
       } as unknown as Subscription;
 
-      it('saves the new balance of the native asset', async () => {
+      it('persists the causing transaction without saving asset balance', async () => {
         await keyringAccountMonitor.setMonitoredAccounts([account.id]);
 
         // Send the notification by manually calling the handler
         const handler = accountNotificationHandlers[0]!;
         await handler(mockNotification, mockSubscription);
-
-        expect(mockAssetsService.save).toHaveBeenCalledWith({
-          assetType: KnownCaip19Id.SolMainnet,
-          keyringAccountId: account.id,
-          network: Network.Mainnet,
-          address: account.address,
-          symbol: 'SOL',
-          decimals: 9,
-          rawAmount: '1000000000',
-          uiAmount: '1',
-        });
 
         expect(mockTransactionsService.save).toHaveBeenCalledWith(
           mockCausingTransaction,
@@ -423,35 +386,6 @@ describe('KeyringAccountMonitor', () => {
         await handler(mockNotification, mockSubscription);
 
         expect(mockTransactionsService.save).not.toHaveBeenCalled();
-      });
-
-      it('throws an error when lamports is missing', async () => {
-        const mockNotificationWithMissingLamports: AccountNotification = {
-          jsonrpc: '2.0',
-          method: 'accountNotification',
-          params: {
-            subscription: 1,
-            result: {
-              context: {
-                slot: 1,
-              },
-              value: {
-                data: {},
-                executable: false,
-                lamports: undefined as unknown as number, // Lamports is missing
-                owner: '11111111111111111111111111111111',
-                rentEpoch: null,
-              },
-            },
-          },
-        };
-
-        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
-
-        const handler = accountNotificationHandlers[0]!;
-        await expect(
-          handler(mockNotificationWithMissingLamports, mockSubscription),
-        ).rejects.toThrow('Expected a number, but received: undefined');
       });
     });
 
@@ -503,44 +437,12 @@ describe('KeyringAccountMonitor', () => {
         params: [TOKEN_PROGRAM_ADDRESS, { commitment: 'confirmed' as const }],
       } as unknown as Subscription;
 
-      beforeEach(() => {
-        jest
-          .spyOn(mockTokenHelper, 'amountToUiAmountForMint')
-          .mockResolvedValue('123.456789');
-      });
-
-      it('tracks ui amount fallback errors and keeps the raw value', async () => {
-        const error = new Error('Conversion failed');
-
-        jest
-          .spyOn(mockTokenHelper, 'amountToUiAmountForMint')
-          .mockRejectedValue(error);
-
+      it('persists the causing transaction without saving token balance', async () => {
         await keyringAccountMonitor.setMonitoredAccounts([account.id]);
 
         const handler = programNotificationHandlers[0]!;
         await handler(mockNotification, mockSubscription);
 
-        expect(trackError).toHaveBeenCalledWith(error);
-      });
-
-      it('saves the new balance of the token asset and the transaction that caused it', async () => {
-        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
-
-        const handler = programNotificationHandlers[0]!;
-        await handler(mockNotification, mockSubscription);
-
-        expect(mockAssetsService.save).toHaveBeenCalledWith({
-          assetType: KnownCaip19Id.UsdcMainnet,
-          keyringAccountId: account.id,
-          network: Network.Mainnet,
-          mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-          pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
-          symbol: 'USDC',
-          decimals: 6,
-          rawAmount: '123456789',
-          uiAmount: '123.456789',
-        });
         expect(mockTransactionsService.save).toHaveBeenCalledWith(
           mockCausingTransaction,
         );
@@ -557,8 +459,8 @@ describe('KeyringAccountMonitor', () => {
         );
       });
 
-      it('throws an error when mint address is missing', async () => {
-        const mockNotificationWithMissingMint: ProgramNotification = {
+      it('throws an error when owner address is missing', async () => {
+        const mockNotificationWithMissingOwner: ProgramNotification = {
           jsonrpc: '2.0',
           method: 'programNotification',
           params: {
@@ -574,8 +476,8 @@ describe('KeyringAccountMonitor', () => {
                     parsed: {
                       info: {
                         isNative: false,
-                        mint: undefined as unknown as string, // Mint is missing
-                        owner: account.address,
+                        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                        owner: undefined as unknown as string, // Owner is missing
                         state: 'initialized',
                         tokenAmount: {
                           amount: '20011079',
@@ -603,60 +505,9 @@ describe('KeyringAccountMonitor', () => {
         const handler = programNotificationHandlers[0]!;
 
         await expect(
-          handler(mockNotificationWithMissingMint, mockSubscription),
+          handler(mockNotificationWithMissingOwner, mockSubscription),
         ).rejects.toThrow('Expected a string, but received: undefined');
-        expect(mockAssetsService.save).not.toHaveBeenCalled();
-      });
-
-      it('throws an error when uiAmountString is missing', async () => {
-        const mockNotificationWithMissingUiAmountString: ProgramNotification = {
-          jsonrpc: '2.0',
-          method: 'programNotification',
-          params: {
-            subscription: 1,
-            result: {
-              context: {
-                slot: 1,
-              },
-              value: {
-                pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
-                account: {
-                  data: {
-                    parsed: {
-                      info: {
-                        isNative: false,
-                        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-                        owner: account.address,
-                        state: 'initialized',
-                        tokenAmount: {
-                          amount: '20011079',
-                          decimals: 6,
-                          uiAmount: 20.011079,
-                          uiAmountString: undefined as unknown as string, // uiAmountString is missing
-                        },
-                      },
-                      type: 'account',
-                    },
-                    program: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-                    space: 165,
-                  },
-                  executable: true,
-                  lamports: 1000000000,
-                  owner: account.address,
-                  rentEpoch: 1,
-                },
-              },
-            },
-          },
-        };
-
-        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
-        const handler = programNotificationHandlers[0]!;
-
-        await expect(
-          handler(mockNotificationWithMissingUiAmountString, mockSubscription),
-        ).rejects.toThrow('Expected a string, but received: undefined');
-        expect(mockAssetsService.save).not.toHaveBeenCalled();
+        expect(mockTransactionsService.save).not.toHaveBeenCalled();
       });
 
       describe('when #saveCausingTransaction encounters errors', () => {

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
@@ -1,8 +1,8 @@
-import { assert, number, string } from '@metamask/superstruct';
+import { assert, string } from '@metamask/superstruct';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 import type { Base58EncodedBytes } from '@solana/kit';
-import { address as asAddress, lamports } from '@solana/kit';
+import { address as asAddress } from '@solana/kit';
 import { get, uniq } from 'lodash';
 
 import type { SubscriptionService } from '.';
@@ -13,15 +13,10 @@ import type {
   Subscription,
 } from '../../../entities';
 import type { Network } from '../../constants/solana';
-import { SolanaCaip19Tokens } from '../../constants/solana';
-import { trackError } from '../../utils/errors';
-import { fromTokenUnits } from '../../utils/fromTokenUnit';
 import { createPrefixedLogger } from '../../utils/logger';
 import type { ILogger } from '../../utils/logger';
-import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
 import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
-import type { AssetsService, TokenHelper } from '../assets';
 import type { ConfigProvider } from '../config';
 import { SUPPORTED_NETWORKS } from '../config/ConfigProvider';
 import type { TransactionsService } from '../transactions';
@@ -34,7 +29,6 @@ import { isSpam } from '../transactions/utils/isSpam';
  * - It gets updates when the balance of token assets change by subscribing to each RPC token account.
  *
  * On each update:
- * - It saves the new balance. Under the hood, AssetsService also notifies the extension.
  * - It fetches the transaction that caused the native asset or token asset to change and saves it. Under the hood, TransactionsService also notifies the extension.
  */
 export class KeyringAccountMonitor {
@@ -42,13 +36,9 @@ export class KeyringAccountMonitor {
 
   readonly #accountService: AccountsService;
 
-  readonly #assetsService: AssetsService;
-
   readonly #transactionsService: TransactionsService;
 
   readonly #accountsSynchronizer: AccountsSynchronizer;
-
-  readonly #tokenHelper: TokenHelper;
 
   readonly #configProvider: ConfigProvider;
 
@@ -62,19 +52,15 @@ export class KeyringAccountMonitor {
   constructor(
     subscriptionService: SubscriptionService,
     accountService: AccountsService,
-    assetsService: AssetsService,
     transactionsService: TransactionsService,
     accountsSynchronizer: AccountsSynchronizer,
-    tokenHelper: TokenHelper,
     configProvider: ConfigProvider,
     logger: ILogger,
   ) {
     this.#subscriptionService = subscriptionService;
     this.#accountService = accountService;
-    this.#assetsService = assetsService;
     this.#transactionsService = transactionsService;
     this.#accountsSynchronizer = accountsSynchronizer;
-    this.#tokenHelper = tokenHelper;
     this.#configProvider = configProvider;
     this.#logger = createPrefixedLogger(logger, '[🗝️ KeyringAccountMonitor]');
 
@@ -322,25 +308,7 @@ export class KeyringAccountMonitor {
       throw new Error(`No keyring account found for address: ${address}`);
     }
 
-    // Handle the notification with clean data
-    const { lamports: accountLamports } = notification.params.result.value;
-    assert(accountLamports, number());
-
-    const decimals = 9;
-
-    await Promise.all([
-      this.#assetsService.save({
-        assetType: `${network}/${SolanaCaip19Tokens.SOL}`,
-        keyringAccountId: keyringAccount.id,
-        network,
-        address,
-        symbol: 'SOL',
-        decimals,
-        rawAmount: accountLamports.toString(),
-        uiAmount: fromTokenUnits(accountLamports, decimals),
-      }),
-      this.#saveCausingTransaction(keyringAccount, network, address),
-    ]);
+    await this.#saveCausingTransaction(keyringAccount, network, address);
   }
 
   async #handleProgramNotification(
@@ -367,60 +335,15 @@ export class KeyringAccountMonitor {
     const { owner } = notification.params.result.value.account.data.parsed.info;
     assert(owner, string());
 
-    const { mint } = notification.params.result.value.account.data.parsed.info;
-    assert(mint, string());
-
-    const { amount, decimals, uiAmountString } =
-      notification.params.result.value.account.data.parsed.info.tokenAmount;
-    assert(amount, string());
-    assert(decimals, number());
-    assert(uiAmountString, string());
-
     const { pubkey } = notification.params.result.value;
     assert(pubkey, string());
-
-    const assetType = tokenAddressToCaip19(network, mint);
 
     const keyringAccount = await this.#accountService.findByAddress(owner);
     if (!keyringAccount) {
       throw new Error(`No keyring account found with address: ${owner}`);
     }
 
-    /**
-     * WARNING: This is to compensate for the fact that the notification returned by Infura's programSubscribe
-     * includes a uiAmount/uiAmountString that does not take into account the mint's multiplier (if any).
-     * In theory, it should; because the regular Solana RPC (wss://api.mainnet-beta.solana.com) does.
-     *
-     * So this needs to be removed once Infura fixes their programSubscribe notification.
-     */
-    const uiAmount = await this.#tokenHelper
-      .amountToUiAmountForMint(mint, network, lamports(BigInt(amount)))
-      .catch(async (error) => {
-        await trackError(error);
-        this.#logger.error('Error converting amount to uiAmount', error);
-        return uiAmountString;
-      });
-
-    const metadata = (await this.#assetsService.getAssetsMetadata([assetType]))[
-      assetType
-    ];
-
-    await Promise.all([
-      // Update the balance of the token asset
-      this.#assetsService.save({
-        assetType,
-        keyringAccountId: keyringAccount.id,
-        network,
-        mint,
-        pubkey,
-        symbol: metadata?.symbol ?? 'UNKNOWN',
-        decimals,
-        rawAmount: amount,
-        uiAmount,
-      }),
-      // Fetch and save the transaction that caused the token asset change.
-      this.#saveCausingTransaction(keyringAccount, network, pubkey),
-    ]);
+    await this.#saveCausingTransaction(keyringAccount, network, pubkey);
   }
 
   /**

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -177,8 +177,8 @@ type CoreAssetsMessenger = Messenger<
   | AssetsControllerGetAccountAssetsByScopeAction
 >;
 
-const coreMessenger = getMessenger<CoreAssetsMessenger>();
-const coreAssetsAdapter = new CoreAssetsAdapter(coreMessenger);
+const coreAssetsMessenger = getMessenger<CoreAssetsMessenger>();
+const coreAssetsAdapter = new CoreAssetsAdapter(coreAssetsMessenger);
 
 const assetsService = new AssetsService({
   logger,
@@ -234,10 +234,8 @@ const signatureMonitor = new SignatureMonitor(
 const keyringAccountMonitor = new KeyringAccountMonitor(
   subscriptionService,
   accountsService,
-  assetsService,
   transactionsService,
   accountsSynchronizer,
-  tokenHelper,
   configProvider,
   logger,
 );


### PR DESCRIPTION
## Summary
- Disable Snap balance tracking in `KeyringAccountMonitor` (transactions only)
- `AccountsSynchronizer` syncs transactions via `getAccountAssetsForAllActiveScopes` (Core reads), no `fetch`/`saveMany`
- Fungible reads remain unconditionally routed through Core (no migration stage conditionals)

## Test plan
- [x] `yarn workspace @metamask/solana-wallet-snap test:core`
- [x] KeyringAccountMonitor tests updated for transaction-only persistence