### PR TITLE
feat(WPN-1476): hardcode CoreAssetsAdapter and remove migration flags (Lane A - PR 5a)

### DIFF
--- a/packages/snap/src/core/services/accounts/AccountsSynchronizer.ts
+++ b/packages/snap/src/core/services/accounts/AccountsSynchronizer.ts
@@ -33,14 +33,12 @@ export class AccountsSynchronizer {
     const assets = (
       await Promise.allSettled(
         accountsToSync.map(async (account) =>
-          this.#assetsService.fetch(account),
+          this.#assetsService.getAccountAssetsForAllActiveScopes(account.id),
         ),
       )
     )
       .map((item) => (item.status === 'fulfilled' ? item.value : []))
       .flat();
-
-    await this.#assetsService.saveMany(assets);
 
     const transactions =
       await this.#transactionsService.fetchAssetsTransactions(assets, {

--- a/packages/snap/src/core/services/assets/AssetsService.test.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.test.ts
@@ -4,6 +4,7 @@ import { KeyringEvent } from '@metamask/keyring-api';
 import { emitSnapKeyringEvent } from '@metamask/keyring-snap-sdk';
 import { cloneDeep } from 'lodash';
 
+import type { AssetEntity } from '../../../entities';
 import type { ICache } from '../../caching/ICache';
 import { InMemoryCache } from '../../caching/InMemoryCache';
 import { MOCK_NFTS_LIST_RESPONSE_MAPPED } from '../../clients/nft-api/mocks/mockNftsListResponseMapped';
@@ -115,6 +116,7 @@ describe('AssetsService', () => {
       configProvider: mockConfigProvider,
       snapAssetsAdapter,
       coreAssetsAdapter: mockCoreAssetsAdapter,
+      accountsService: mockAccountsService,
       tokenApiClient: mockTokenApiClient,
       tokenPricesService: mockTokenPricesService,
       nftApiClient: mockNftApiClient,
@@ -634,23 +636,47 @@ describe('AssetsService', () => {
   });
 
   describe('getAccountAssetByID', () => {
-    it('returns the matching asset when present', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
+    it('routes fungible assets through CoreAssetsAdapter', async () => {
+      jest.spyOn(mockCoreAssetsAdapter, 'getAccountAsset').mockResolvedValueOnce(
+        MOCK_ASSET_ENTITY_1,
+      );
 
       const asset = await assetsService.getAccountAssetByID(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
         MOCK_ASSET_ENTITY_1.assetType,
       );
 
+      expect(mockCoreAssetsAdapter.getAccountAsset).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_ASSET_ENTITY_1.assetType,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+      );
       expect(asset).toStrictEqual(MOCK_ASSET_ENTITY_1);
     });
 
-    it('returns null when the asset is missing', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce([]);
+    it('routes NFT assets through SnapAssetsAdapter', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const snapSpy = jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetByID')
+        .mockResolvedValueOnce(null);
+
+      await assetsService.getAccountAssetByID(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        nftAssetType,
+      );
+
+      expect(snapSpy).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        nftAssetType,
+      );
+      expect(mockCoreAssetsAdapter.getAccountAsset).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the fungible asset is missing from Core', async () => {
+      jest.spyOn(mockCoreAssetsAdapter, 'getAccountAsset').mockResolvedValueOnce(
+        null,
+      );
 
       const asset = await assetsService.getAccountAssetByID(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
@@ -662,51 +688,115 @@ describe('AssetsService', () => {
   });
 
   describe('getAccountAssetsByIDs', () => {
-    it('returns a record keyed by asset ID', async () => {
+    it('routes fungible and NFT asset IDs to the correct adapters', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
-
-      const assets = await assetsService.getAccountAssetsByIDs(
-        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
-        [MOCK_ASSET_ENTITY_0.assetType, MOCK_ASSET_ENTITY_1.assetType],
-      );
-
-      expect(assets).toStrictEqual({
-        [MOCK_ASSET_ENTITY_0.assetType]: MOCK_ASSET_ENTITY_0,
-        [MOCK_ASSET_ENTITY_1.assetType]: MOCK_ASSET_ENTITY_1,
-      });
-    });
-
-    it('returns null entries for missing assets', async () => {
-      jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssetsByIds')
         .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0]);
+      jest.spyOn(snapAssetsAdapter, 'getAccountAssetsByIDs').mockResolvedValueOnce(
+        {
+          [nftAssetType]: null,
+        },
+      );
 
       const assets = await assetsService.getAccountAssetsByIDs(
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
-        [MOCK_ASSET_ENTITY_0.assetType, MOCK_ASSET_ENTITY_1.assetType],
+        [MOCK_ASSET_ENTITY_0.assetType, nftAssetType],
       );
 
+      expect(mockCoreAssetsAdapter.getAccountAssetsByIds).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        [MOCK_ASSET_ENTITY_0.assetType],
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        [Network.Mainnet],
+      );
+      expect(snapAssetsAdapter.getAccountAssetsByIDs).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        [nftAssetType],
+      );
       expect(assets).toStrictEqual({
         [MOCK_ASSET_ENTITY_0.assetType]: MOCK_ASSET_ENTITY_0,
-        [MOCK_ASSET_ENTITY_1.assetType]: null,
+        [nftAssetType]: null,
       });
     });
   });
 
   describe('getAccountAssetsByScope', () => {
-    it('filters account assets to the requested scope', async () => {
+    it('merges fungible Core assets with Snap-owned NFT assets for the scope', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const nftAsset = {
+        assetType: nftAssetType,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
+        symbol: 'NFT',
+        decimals: 0,
+        rawAmount: '1',
+        uiAmount: '1',
+      } as AssetEntity;
+
       jest
-        .spyOn(mockAssetsRepository, 'findByKeyringAccountId')
-        .mockResolvedValueOnce(MOCK_ASSET_ENTITIES);
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssets')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0, MOCK_ASSET_ENTITY_1]);
+      jest.spyOn(snapAssetsAdapter, 'getAccountAssetsByScope').mockResolvedValueOnce(
+        [MOCK_ASSET_ENTITY_2, nftAsset],
+      );
 
       const assets = await assetsService.getAccountAssetsByScope(
         Network.Mainnet,
         MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
       );
 
-      expect(assets).toStrictEqual(MOCK_ASSET_ENTITIES);
+      expect(mockCoreAssetsAdapter.getAccountAssets).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        [Network.Mainnet],
+      );
+      expect(assets).toStrictEqual([
+        MOCK_ASSET_ENTITY_0,
+        MOCK_ASSET_ENTITY_1,
+        nftAsset,
+      ]);
+    });
+  });
+
+  describe('getAccountAssetsForAllActiveScopes', () => {
+    it('merges fungible Core assets with Snap-owned NFT assets across active scopes', async () => {
+      const nftAssetType =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const nftAsset = {
+        assetType: nftAssetType,
+        keyringAccountId: MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        network: Network.Mainnet,
+        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
+        symbol: 'NFT',
+        decimals: 0,
+        rawAmount: '1',
+        uiAmount: '1',
+      } as AssetEntity;
+
+      jest
+        .spyOn(mockCoreAssetsAdapter, 'getAccountAssets')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_0]);
+      jest
+        .spyOn(snapAssetsAdapter, 'getAccountAssetsForAllActiveScopes')
+        .mockResolvedValueOnce([MOCK_ASSET_ENTITY_1, nftAsset]);
+
+      const assets = await assetsService.getAccountAssetsForAllActiveScopes(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+      );
+
+      expect(mockCoreAssetsAdapter.getAccountAssets).toHaveBeenCalledWith(
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.id,
+        MOCK_SOLANA_KEYRING_ACCOUNT_0.address,
+        [Network.Mainnet],
+      );
+      expect(assets).toStrictEqual([MOCK_ASSET_ENTITY_0, nftAsset]);
     });
   });
 });

--- a/packages/snap/src/core/services/assets/AssetsService.ts
+++ b/packages/snap/src/core/services/assets/AssetsService.ts
@@ -18,10 +18,12 @@ import type {
 import { SolanaCaip19Tokens } from '../../constants/solana';
 import type { Caip10Address } from '../../constants/solana';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
+import type { AccountsService } from '../accounts/AccountsService';
 import type { ConfigProvider } from '../config';
 import type { TokenPricesService } from '../token-prices/TokenPrices';
 import type { CoreAssetsAdapter } from './adapters/CoreAssetsAdapter';
 import { SnapAssetsAdapter } from './adapters/SnapAssetsAdapter';
+import { isSnapOwnedAsset } from './snapOwnedAssets';
 import type { AssetMetadata, NonFungibleAssetMetadata } from './types';
 
 export class AssetsService {
@@ -31,8 +33,9 @@ export class AssetsService {
 
   readonly #snapAdapter: SnapAssetsAdapter;
 
-  /** Reserved for migration routing in a follow-up PR; not used for reads yet. */
   readonly #coreAssetsAdapter: CoreAssetsAdapter;
+
+  readonly #accountsService: AccountsService;
 
   readonly #tokenPricesService: TokenPricesService;
 
@@ -45,6 +48,7 @@ export class AssetsService {
     configProvider,
     snapAssetsAdapter,
     coreAssetsAdapter,
+    accountsService,
     tokenApiClient,
     tokenPricesService,
     nftApiClient,
@@ -53,6 +57,7 @@ export class AssetsService {
     configProvider: ConfigProvider;
     snapAssetsAdapter: SnapAssetsAdapter;
     coreAssetsAdapter: CoreAssetsAdapter;
+    accountsService: AccountsService;
     tokenApiClient: TokenApiClient;
     tokenPricesService: TokenPricesService;
     nftApiClient: NftApiClient;
@@ -61,9 +66,14 @@ export class AssetsService {
     this.#configProvider = configProvider;
     this.#snapAdapter = snapAssetsAdapter;
     this.#coreAssetsAdapter = coreAssetsAdapter;
+    this.#accountsService = accountsService;
     this.#tokenApiClient = tokenApiClient;
     this.#tokenPricesService = tokenPricesService;
     this.#nftApiClient = nftApiClient;
+  }
+
+  async #solanaChainIds(): Promise<string[]> {
+    return this.#configProvider.getActiveNetworks();
   }
 
   #splitAssetsByType(assetTypes: CaipAssetType[]) {
@@ -139,7 +149,7 @@ export class AssetsService {
         imageUrl: nftMetadata.imageUrl,
         description: nftMetadata.description,
         fungible: false as const,
-        isPossibleSpam: false, // FIXME: The isSpam should be part of the NFT item response, not balance, otherwise we can't get it here
+        isPossibleSpam: false,
         attributes: Object.fromEntries(
           nftMetadata.attributes.map(
             (attr: { key: string; value: string | number }) => [
@@ -153,7 +163,7 @@ export class AssetsService {
           address: nftMetadata.onchainCollectionAddress as Caip10Address,
           symbol: nftMetadata.collectionSymbol,
           tokenCount: nftMetadata.collectionCount,
-          creator: '' as Caip10Address, // FIXME: There can be more than one creator
+          creator: '' as Caip10Address,
           imageUrl: nftMetadata.collectionImageUrl ?? '',
         },
       };
@@ -169,23 +179,17 @@ export class AssetsService {
   ): Promise<Record<CaipAssetType, AssetMetadata | null>> {
     this.#logger.log('Fetching metadata for assets', assetTypes);
 
-    const { nativeAssetTypes, tokenAssetTypes, nftAssetTypes } =
+    const { nativeAssetTypes, tokenAssetTypes } =
       this.#splitAssetsByType(assetTypes);
 
-    const [
-      nativeTokensMetadata,
-      tokensMetadata,
-      // nftMetadata,
-    ] = await Promise.all([
+    const [nativeTokensMetadata, tokensMetadata] = await Promise.all([
       this.#getNativeTokensMetadata(nativeAssetTypes),
       this.#tokenApiClient.getTokensMetadata(tokenAssetTypes),
-      // this.#getNftsMetadata(nftAssetTypes),
     ]);
 
     return {
       ...nativeTokensMetadata,
       ...tokensMetadata,
-      // ...nftMetadata,
     };
   }
 
@@ -216,13 +220,6 @@ export class AssetsService {
     return this.#snapAdapter.saveMany(assets);
   }
 
-  /**
-   * Checks if the asset has changed compared to passed assets lookup.
-   *
-   * @param asset - The asset to check.
-   * @param assetsLookup - The lookup table to check against.
-   * @returns True if the asset has changed, false otherwise.
-   */
   static hasChanged(asset: AssetEntity, assetsLookup: AssetEntity[]): boolean {
     return SnapAssetsAdapter.hasChanged(asset, assetsLookup);
   }
@@ -231,55 +228,113 @@ export class AssetsService {
     return this.#snapAdapter.getAll();
   }
 
-  /**
-   * Returns a single account asset by CAIP-19 ID, or `null` if missing.
-   *
-   * @param accountId - Keyring account ID.
-   * @param assetId - CAIP-19 asset ID.
-   */
   async getAccountAssetByID(
     accountId: string,
     assetId: string,
   ): Promise<AssetEntity | null> {
-    return this.#snapAdapter.getAccountAssetByID(accountId, assetId);
+    if (isSnapOwnedAsset(assetId)) {
+      return this.#snapAdapter.getAccountAssetByID(accountId, assetId);
+    }
+
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return null;
+    }
+
+    return this.#coreAssetsAdapter.getAccountAsset(
+      accountId,
+      assetId,
+      account.address,
+    );
   }
 
-  /**
-   * Returns account assets for the given CAIP-19 IDs, keyed by asset ID.
-   * Missing assets are `null`.
-   *
-   * @param accountId - Keyring account ID.
-   * @param assetIds - CAIP-19 asset IDs to resolve.
-   */
   async getAccountAssetsByIDs(
     accountId: string,
     assetIds: string[],
   ): Promise<Record<string, AssetEntity | null>> {
-    return this.#snapAdapter.getAccountAssetsByIDs(accountId, assetIds);
+    if (assetIds.length === 0) {
+      return {};
+    }
+
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return Object.fromEntries(assetIds.map((assetId) => [assetId, null]));
+    }
+
+    const snapOwnedIds = assetIds.filter(isSnapOwnedAsset);
+    const fungibleIds = assetIds.filter((assetId) => !isSnapOwnedAsset(assetId));
+    const chainIds = await this.#solanaChainIds();
+
+    const [fungibleResults, snapResults] = await Promise.all([
+      fungibleIds.length > 0
+        ? this.#coreAssetsAdapter.getAccountAssetsByIds(
+            accountId,
+            fungibleIds,
+            account.address,
+            chainIds,
+          )
+        : Promise.resolve([]),
+      snapOwnedIds.length > 0
+        ? this.#snapAdapter.getAccountAssetsByIDs(accountId, snapOwnedIds)
+        : Promise.resolve({}),
+    ]);
+
+    const result: Record<string, AssetEntity | null> = { ...snapResults };
+    fungibleIds.forEach((assetId, index) => {
+      result[assetId] = fungibleResults[index] ?? null;
+    });
+
+    return result;
   }
 
-  /**
-   * Returns controller-backed assets for an account on the given Solana scope.
-   *
-   * @param scope - CAIP-2 chain ID to filter results.
-   * @param accountId - Keyring account ID.
-   */
   async getAccountAssetsByScope(
     scope: CaipChainId,
     accountId: string,
   ): Promise<AssetEntity[]> {
-    return this.#snapAdapter.getAccountAssetsByScope(scope, accountId);
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return [];
+    }
+
+    const [fungibleAssets, snapAssets] = await Promise.all([
+      this.#coreAssetsAdapter.getAccountAssets(
+        accountId,
+        account.address,
+        [scope],
+      ),
+      this.#snapAdapter.getAccountAssetsByScope(scope, accountId),
+    ]);
+
+    const nftAssets = snapAssets.filter((asset) =>
+      isSnapOwnedAsset(asset.assetType),
+    );
+
+    return [...fungibleAssets, ...nftAssets];
   }
 
-  /**
-   * Returns assets for an account across all active Solana networks.
-   *
-   * @param accountId - Keyring account ID.
-   */
   async getAccountAssetsForAllActiveScopes(
     accountId: string,
   ): Promise<AssetEntity[]> {
-    return this.#snapAdapter.getAccountAssetsForAllActiveScopes(accountId);
+    const account = await this.#accountsService.findById(accountId);
+    if (!account) {
+      return [];
+    }
+
+    const chainIds = await this.#solanaChainIds();
+    const [fungibleAssets, snapAssets] = await Promise.all([
+      this.#coreAssetsAdapter.getAccountAssets(
+        accountId,
+        account.address,
+        chainIds,
+      ),
+      this.#snapAdapter.getAccountAssetsForAllActiveScopes(accountId),
+    ]);
+
+    const nftAssets = snapAssets.filter((asset) =>
+      isSnapOwnedAsset(asset.assetType),
+    );
+
+    return [...fungibleAssets, ...nftAssets];
   }
 
   async findByAccount(account: SolanaKeyringAccount): Promise<AssetEntity[]> {

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.test.ts
@@ -17,7 +17,6 @@ import { KnownCaip19Id, Network } from '../../constants/solana';
 import { MOCK_SOLANA_KEYRING_ACCOUNTS } from '../../test/mocks/solana-keyring-accounts';
 import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
-import type { AssetsService, TokenHelper } from '../assets';
 import type { ConfigProvider } from '../config';
 import { mockLogger } from '../mocks/logger';
 import type { TransactionsService } from '../transactions';
@@ -28,10 +27,8 @@ describe('KeyringAccountMonitor', () => {
   let keyringAccountMonitor: KeyringAccountMonitor;
   let mockSubscriptionService: SubscriptionService;
   let mockAccountService: AccountsService;
-  let mockAssetsService: AssetsService;
   let mockTransactionsService: TransactionsService;
   let mockAccountsSynchronizer: AccountsSynchronizer;
-  let mockTokenHelper: TokenHelper;
   let mockConfigProvider: ConfigProvider;
 
   const account = MOCK_SOLANA_KEYRING_ACCOUNTS[0];
@@ -118,17 +115,6 @@ describe('KeyringAccountMonitor', () => {
       findByAddress: jest.fn(),
     } as unknown as AccountsService;
 
-    mockAssetsService = {
-      getTokenAccountsByOwnerMultiple: jest.fn(),
-      save: jest.fn(),
-      getAssetsMetadata: jest.fn().mockImplementation((assetType) => ({
-        [assetType]: {
-          symbol: 'USDC',
-          decimals: 6,
-        },
-      })),
-    } as unknown as AssetsService;
-
     mockTransactionsService = {
       fetchLatestSignatures: jest.fn(),
       fetchBySignature: jest.fn(),
@@ -139,11 +125,6 @@ describe('KeyringAccountMonitor', () => {
       synchronize: jest.fn(),
     } as unknown as AccountsSynchronizer;
 
-    mockTokenHelper = {
-      uiAmountToAmountForMint: jest.fn(),
-      amountToUiAmountForMint: jest.fn(),
-    } as unknown as TokenHelper;
-
     mockConfigProvider = {
       getActiveNetworks: jest
         .fn()
@@ -153,10 +134,8 @@ describe('KeyringAccountMonitor', () => {
     keyringAccountMonitor = new KeyringAccountMonitor(
       mockSubscriptionService,
       mockAccountService,
-      mockAssetsService,
       mockTransactionsService,
       mockAccountsSynchronizer,
-      mockTokenHelper,
       mockConfigProvider,
       mockLogger,
     );
@@ -355,23 +334,12 @@ describe('KeyringAccountMonitor', () => {
         params: [account.address, { commitment: 'confirmed' as const }],
       } as unknown as Subscription;
 
-      it('saves the new balance of the native asset', async () => {
+      it('persists the causing transaction without saving asset balance', async () => {
         await keyringAccountMonitor.setMonitoredAccounts([account.id]);
 
         // Send the notification by manually calling the handler
         const handler = accountNotificationHandlers[0]!;
         await handler(mockNotification, mockSubscription);
-
-        expect(mockAssetsService.save).toHaveBeenCalledWith({
-          assetType: KnownCaip19Id.SolMainnet,
-          keyringAccountId: account.id,
-          network: Network.Mainnet,
-          address: account.address,
-          symbol: 'SOL',
-          decimals: 9,
-          rawAmount: '1000000000',
-          uiAmount: '1',
-        });
 
         expect(mockTransactionsService.save).toHaveBeenCalledWith(
           mockCausingTransaction,
@@ -417,35 +385,6 @@ describe('KeyringAccountMonitor', () => {
         await handler(mockNotification, mockSubscription);
 
         expect(mockTransactionsService.save).not.toHaveBeenCalled();
-      });
-
-      it('throws an error when lamports is missing', async () => {
-        const mockNotificationWithMissingLamports: AccountNotification = {
-          jsonrpc: '2.0',
-          method: 'accountNotification',
-          params: {
-            subscription: 1,
-            result: {
-              context: {
-                slot: 1,
-              },
-              value: {
-                data: {},
-                executable: false,
-                lamports: undefined as unknown as number, // Lamports is missing
-                owner: '11111111111111111111111111111111',
-                rentEpoch: null,
-              },
-            },
-          },
-        };
-
-        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
-
-        const handler = accountNotificationHandlers[0]!;
-        await expect(
-          handler(mockNotificationWithMissingLamports, mockSubscription),
-        ).rejects.toThrow('Expected a number, but received: undefined');
       });
     });
 
@@ -497,29 +436,12 @@ describe('KeyringAccountMonitor', () => {
         params: [TOKEN_PROGRAM_ADDRESS, { commitment: 'confirmed' as const }],
       } as unknown as Subscription;
 
-      beforeEach(() => {
-        jest
-          .spyOn(mockTokenHelper, 'amountToUiAmountForMint')
-          .mockResolvedValue('123.456789');
-      });
-
-      it('saves the new balance of the token asset and the transaction that caused it', async () => {
+      it('persists the causing transaction without saving token balance', async () => {
         await keyringAccountMonitor.setMonitoredAccounts([account.id]);
 
         const handler = programNotificationHandlers[0]!;
         await handler(mockNotification, mockSubscription);
 
-        expect(mockAssetsService.save).toHaveBeenCalledWith({
-          assetType: KnownCaip19Id.UsdcMainnet,
-          keyringAccountId: account.id,
-          network: Network.Mainnet,
-          mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-          pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
-          symbol: 'USDC',
-          decimals: 6,
-          rawAmount: '123456789',
-          uiAmount: '123.456789',
-        });
         expect(mockTransactionsService.save).toHaveBeenCalledWith(
           mockCausingTransaction,
         );
@@ -536,8 +458,8 @@ describe('KeyringAccountMonitor', () => {
         );
       });
 
-      it('throws an error when mint address is missing', async () => {
-        const mockNotificationWithMissingMint: ProgramNotification = {
+      it('throws an error when owner address is missing', async () => {
+        const mockNotificationWithMissingOwner: ProgramNotification = {
           jsonrpc: '2.0',
           method: 'programNotification',
           params: {
@@ -553,8 +475,8 @@ describe('KeyringAccountMonitor', () => {
                     parsed: {
                       info: {
                         isNative: false,
-                        mint: undefined as unknown as string, // Mint is missing
-                        owner: account.address,
+                        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                        owner: undefined as unknown as string, // Owner is missing
                         state: 'initialized',
                         tokenAmount: {
                           amount: '20011079',
@@ -582,60 +504,9 @@ describe('KeyringAccountMonitor', () => {
         const handler = programNotificationHandlers[0]!;
 
         await expect(
-          handler(mockNotificationWithMissingMint, mockSubscription),
+          handler(mockNotificationWithMissingOwner, mockSubscription),
         ).rejects.toThrow('Expected a string, but received: undefined');
-        expect(mockAssetsService.save).not.toHaveBeenCalled();
-      });
-
-      it('throws an error when uiAmountString is missing', async () => {
-        const mockNotificationWithMissingUiAmountString: ProgramNotification = {
-          jsonrpc: '2.0',
-          method: 'programNotification',
-          params: {
-            subscription: 1,
-            result: {
-              context: {
-                slot: 1,
-              },
-              value: {
-                pubkey: '9wt9PfjPD3JCy5r7o4K1cTGiuTG7fq2pQhdDCdQALKjg',
-                account: {
-                  data: {
-                    parsed: {
-                      info: {
-                        isNative: false,
-                        mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-                        owner: account.address,
-                        state: 'initialized',
-                        tokenAmount: {
-                          amount: '20011079',
-                          decimals: 6,
-                          uiAmount: 20.011079,
-                          uiAmountString: undefined as unknown as string, // uiAmountString is missing
-                        },
-                      },
-                      type: 'account',
-                    },
-                    program: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-                    space: 165,
-                  },
-                  executable: true,
-                  lamports: 1000000000,
-                  owner: account.address,
-                  rentEpoch: 1,
-                },
-              },
-            },
-          },
-        };
-
-        await keyringAccountMonitor.setMonitoredAccounts([account.id]);
-        const handler = programNotificationHandlers[0]!;
-
-        await expect(
-          handler(mockNotificationWithMissingUiAmountString, mockSubscription),
-        ).rejects.toThrow('Expected a string, but received: undefined');
-        expect(mockAssetsService.save).not.toHaveBeenCalled();
+        expect(mockTransactionsService.save).not.toHaveBeenCalled();
       });
 
       describe('when #saveCausingTransaction encounters errors', () => {

--- a/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
+++ b/packages/snap/src/core/services/subscriptions/KeyringAccountMonitor.ts
@@ -1,9 +1,9 @@
 /* eslint-disable jsdoc/check-indentation */
-import { assert, number, string } from '@metamask/superstruct';
+import { assert, string } from '@metamask/superstruct';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 import type { Base58EncodedBytes } from '@solana/kit';
-import { address as asAddress, lamports } from '@solana/kit';
+import { address as asAddress } from '@solana/kit';
 import { get, uniq } from 'lodash';
 
 import type { SubscriptionService } from '.';
@@ -14,13 +14,9 @@ import type {
   Subscription,
 } from '../../../entities';
 import type { Network } from '../../constants/solana';
-import { SolanaCaip19Tokens } from '../../constants/solana';
-import { fromTokenUnits } from '../../utils/fromTokenUnit';
 import { createPrefixedLogger, type ILogger } from '../../utils/logger';
-import { tokenAddressToCaip19 } from '../../utils/tokenAddressToCaip19';
 import type { AccountsSynchronizer } from '../accounts';
 import type { AccountsService } from '../accounts/AccountsService';
-import type { AssetsService, TokenHelper } from '../assets';
 import type { ConfigProvider } from '../config';
 import { SUPPORTED_NETWORKS } from '../config/ConfigProvider';
 import type { TransactionsService } from '../transactions';
@@ -33,7 +29,6 @@ import { isSpam } from '../transactions/utils/isSpam';
  * - It gets updates when the balance of token assets change by subscribing to each RPC token account.
  *
  * On each update:
- * - It saves the new balance. Under the hood, AssetsService also notifies the extension.
  * - It fetches the transaction that caused the native asset or token asset to change and saves it. Under the hood, TransactionsService also notifies the extension.
  */
 export class KeyringAccountMonitor {
@@ -41,13 +36,9 @@ export class KeyringAccountMonitor {
 
   readonly #accountService: AccountsService;
 
-  readonly #assetsService: AssetsService;
-
   readonly #transactionsService: TransactionsService;
 
   readonly #accountsSynchronizer: AccountsSynchronizer;
-
-  readonly #tokenHelper: TokenHelper;
 
   readonly #configProvider: ConfigProvider;
 
@@ -61,19 +52,15 @@ export class KeyringAccountMonitor {
   constructor(
     subscriptionService: SubscriptionService,
     accountService: AccountsService,
-    assetsService: AssetsService,
     transactionsService: TransactionsService,
     accountsSynchronizer: AccountsSynchronizer,
-    tokenHelper: TokenHelper,
     configProvider: ConfigProvider,
     logger: ILogger,
   ) {
     this.#subscriptionService = subscriptionService;
     this.#accountService = accountService;
-    this.#assetsService = assetsService;
     this.#transactionsService = transactionsService;
     this.#accountsSynchronizer = accountsSynchronizer;
-    this.#tokenHelper = tokenHelper;
     this.#configProvider = configProvider;
     this.#logger = createPrefixedLogger(logger, '[🗝️ KeyringAccountMonitor]');
 
@@ -317,25 +304,7 @@ export class KeyringAccountMonitor {
       throw new Error(`No keyring account found for address: ${address}`);
     }
 
-    // Handle the notification with clean data
-    const { lamports: accountLamports } = notification.params.result.value;
-    assert(accountLamports, number());
-
-    const decimals = 9;
-
-    await Promise.all([
-      this.#assetsService.save({
-        assetType: `${network}/${SolanaCaip19Tokens.SOL}`,
-        keyringAccountId: keyringAccount.id,
-        network,
-        address,
-        symbol: 'SOL',
-        decimals,
-        rawAmount: accountLamports.toString(),
-        uiAmount: fromTokenUnits(accountLamports, decimals),
-      }),
-      this.#saveCausingTransaction(keyringAccount, network, address),
-    ]);
+    await this.#saveCausingTransaction(keyringAccount, network, address);
   }
 
   async #handleProgramNotification(
@@ -362,59 +331,15 @@ export class KeyringAccountMonitor {
     const { owner } = notification.params.result.value.account.data.parsed.info;
     assert(owner, string());
 
-    const { mint } = notification.params.result.value.account.data.parsed.info;
-    assert(mint, string());
-
-    const { amount, decimals, uiAmountString } =
-      notification.params.result.value.account.data.parsed.info.tokenAmount;
-    assert(amount, string());
-    assert(decimals, number());
-    assert(uiAmountString, string());
-
     const { pubkey } = notification.params.result.value;
     assert(pubkey, string());
-
-    const assetType = tokenAddressToCaip19(network, mint);
 
     const keyringAccount = await this.#accountService.findByAddress(owner);
     if (!keyringAccount) {
       throw new Error(`No keyring account found with address: ${owner}`);
     }
 
-    /**
-     * WARNING: This is to compensate for the fact that the notification returned by Infura's programSubscribe
-     * includes a uiAmount/uiAmountString that does not take into account the mint's multiplier (if any).
-     * In theory, it should; because the regular Solana RPC (wss://api.mainnet-beta.solana.com) does.
-     *
-     * So this needs to be removed once Infura fixes their programSubscribe notification.
-     */
-    const uiAmount = await this.#tokenHelper
-      .amountToUiAmountForMint(mint, network, lamports(BigInt(amount)))
-      .catch((error) => {
-        this.#logger.error('Error converting amount to uiAmount', error);
-        return uiAmountString;
-      });
-
-    const metadata = (await this.#assetsService.getAssetsMetadata([assetType]))[
-      assetType
-    ];
-
-    await Promise.all([
-      // Update the balance of the token asset
-      this.#assetsService.save({
-        assetType,
-        keyringAccountId: keyringAccount.id,
-        network,
-        mint,
-        pubkey,
-        symbol: metadata?.symbol ?? 'UNKNOWN',
-        decimals,
-        rawAmount: amount,
-        uiAmount,
-      }),
-      // Fetch and save the transaction that caused the token asset change.
-      this.#saveCausingTransaction(keyringAccount, network, pubkey),
-    ]);
+    await this.#saveCausingTransaction(keyringAccount, network, pubkey);
   }
 
   /**

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -172,6 +172,7 @@ const assetsService = new AssetsService({
   configProvider,
   snapAssetsAdapter,
   coreAssetsAdapter,
+  accountsService,
   tokenApiClient,
   tokenPricesService,
   nftApiClient,

--- a/packages/snap/src/snapContext.ts
+++ b/packages/snap/src/snapContext.ts
@@ -221,10 +221,8 @@ const signatureMonitor = new SignatureMonitor(
 const keyringAccountMonitor = new KeyringAccountMonitor(
   subscriptionService,
   accountsService,
-  assetsService,
   transactionsService,
   accountsSynchronizer,
-  tokenHelper,
   configProvider,
   logger,
 );


### PR DESCRIPTION
## Summary
- Remove migration flag resolution; hardcode fungible reads through `CoreAssetsAdapter`
- Permanently disable Snap fungible tracking (`fetch`/`saveMany` no-ops)
- `AccountsSynchronizer` and `KeyringAccountMonitor` use Core asset lists for tx sync only

## Test plan
- [x] `yarn workspace @metamask/solana-wallet-snap test:core`