### PR TITLE
chore: add archive banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/internal-snaps"><code>internal-snaps</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over. Also, please re-open PRs that are under active development in the <code>internal-snaps</code> repo.</p></td></tr></table>
+<table>
+  <tr>
+    <td>
+      <p align="center"><b>⚠️ PLEASE READ ⚠️</b></p>
+      <p align="center">
+        This package has been migrated to our
+        <a href="https://github.com/MetaMask/internal-snaps"
+          ><code>internal-snaps</code></a
+        >
+        monorepo, and this repository has been archived. Please note that all
+        future development and feature releases will take place in the
+        <a href="https://github.com/MetaMask/internal-snaps"
+          ><code>internal-snaps</code></a
+        >
+        repository.
+      </p>
+    </td>
+  </tr>
+</table>
 
 # Solana Wallet Snap Monorepo
 


### PR DESCRIPTION
Add archive banner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Updates the top-of-README warning banner to reflect that migration is **complete** and this repo is **archived**, steering readers to **`internal-snaps`** for ongoing work instead of the previous “migration in progress—don’t commit” message.
> 
> The banner HTML is also **reformatted** from a single-line table to a multi-line layout (same link and messaging structure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbf508601e3de1b60e2e406afc89c25307dfdeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->